### PR TITLE
[#157] GitHub Pages(静的書き出し)がVercelホストAPIにビルド時依存しており壊れやすい

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
+# node:test の一時トランスパイル成果物（after フックで削除されるが、異常終了時の残留に備える）
+*.test-build.mjs
+.getPostData.pageserver-build.mjs
+
 # .env.local
 # .env.production
 

--- a/src/app/(pages)/blog/[slug]/page.server.test.mjs
+++ b/src/app/(pages)/blog/[slug]/page.server.test.mjs
@@ -1,0 +1,176 @@
+// blog/[slug]/page.server.tsx の振る舞い契約を検証する単体テスト（Issue #157 / TDD 先行）。
+//
+// #157 の根本原因は generateStaticParams / getBlogArticle がビルド時に外部 API を fetch し、
+// API 障害・URL 変更でビルドが落ちること。本テストは「外部 API に依存せずローカルの記事
+// （src/posts/*.mdx）から静的パラメータ・記事本文を生成する」契約を固定する。
+//
+// 本リポジトリは JS テストランナー未導入のため、既存の getPostData.test.mjs と同様に
+// Node 組み込み `node:test` と devDependency の `typescript` のみで構成する（新規パッケージ無し）。
+// 対象は TSX かつ `@/` エイリアスと getPostData への依存を持つため、実コードをインメモリで
+// JS へトランスパイルし、エイリアス import を実体へ張り替えて動的 import する。
+//
+// 実行: プロジェクトルートで
+//   node --test 'src/app/(pages)/blog/[slug]/page.server.test.mjs'
+//
+// 重要: 本テストは「API がダウンしていてもローカルから生成できる」という #157 の要件を
+// ハーミティックに固定するため、テスト中は globalThis.fetch を強制失敗（API ダウン相当）に
+// 差し替える。fetch 依存実装ならここで throw して RED、ローカル直読み実装なら fetch を
+// 一切呼ばず GREEN になる（実環境で localhost:3000 が応答するか否かに左右されない）。
+
+import matter from 'gray-matter'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { after, before, describe, it } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const PAGESERVER_SRC = path.join(__dirname, 'page.server.tsx')
+const PAGESERVER_BUILD = path.join(__dirname, '.page.server.test-build.mjs')
+
+const POSTDATA_SRC = path.join(
+  process.cwd(),
+  'src',
+  'app',
+  'api',
+  'utils',
+  'getPostData.tsx',
+)
+const POSTDATA_BUILD = path.join(
+  process.cwd(),
+  'src',
+  'app',
+  'api',
+  'utils',
+  '.getPostData.pageserver-build.mjs',
+)
+
+const POSTS_DIR = path.join(process.cwd(), 'src', 'posts')
+const LIMITED_TAG = '限定公開'
+
+const transpile = (srcPath) => {
+  const source = fs.readFileSync(srcPath, 'utf8')
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+  }).outputText
+}
+
+// page.server.tsx は getPostData を `@/` エイリアスで参照する。テストでは依存の getPostData を
+// 先に JS へトランスパイルし、その実体（相対パス）へ import 指定子を張り替えてから読み込む。
+const loadModule = async () => {
+  fs.writeFileSync(POSTDATA_BUILD, transpile(POSTDATA_SRC))
+
+  const relToPostData =
+    './' + path.relative(__dirname, POSTDATA_BUILD).split(path.sep).join('/')
+
+  const pageServer = transpile(PAGESERVER_SRC).replaceAll(
+    '@/app/api/utils/getPostData',
+    relToPostData,
+  )
+  fs.writeFileSync(PAGESERVER_BUILD, pageServer)
+
+  return import(`${PAGESERVER_BUILD}?t=${process.pid}`)
+}
+
+// 公開（限定公開を除く）記事の slug 集合を独立に算出するオラクル。
+const readPublishedSlugs = () => {
+  return fs
+    .readdirSync(POSTS_DIR)
+    .filter((name) => name.endsWith('.mdx'))
+    .map((name) => {
+      const slug = name.replace(/\.mdx$/, '')
+      const { data } = matter(
+        fs.readFileSync(path.join(POSTS_DIR, name), 'utf8'),
+      )
+      return { slug, tags: data.tags || [] }
+    })
+    .filter((post) => !post.tags.includes(LIMITED_TAG))
+    .map((post) => post.slug)
+}
+
+describe('blog/[slug]/page.server.tsx（Issue #157: ローカル直読み）', () => {
+  let generateStaticParams
+  let getBlogArticle
+  let params
+  let fetchCalls
+  const originalFetch = globalThis.fetch
+
+  before(async () => {
+    // API ダウン（および「外部 fetch を一切しない」こと）を保証するため fetch を差し替える。
+    fetchCalls = 0
+    globalThis.fetch = async (...callArgs) => {
+      fetchCalls += 1
+      throw new Error(`API down (fetch must not be called): ${callArgs[0]}`)
+    }
+
+    const mod = await loadModule()
+    generateStaticParams = mod.generateStaticParams
+    getBlogArticle = mod.getBlogArticle
+    if (typeof generateStaticParams === 'function') {
+      params = await generateStaticParams()
+    }
+  })
+
+  after(() => {
+    globalThis.fetch = originalFetch
+    if (fs.existsSync(PAGESERVER_BUILD)) fs.rmSync(PAGESERVER_BUILD)
+    if (fs.existsSync(POSTDATA_BUILD)) fs.rmSync(POSTDATA_BUILD)
+  })
+
+  it('外部 API を一切 fetch しない（ビルド時のリモート依存を持たない）', () => {
+    // Given: テスト中は fetch が必ず throw する（API ダウン相当）
+    // When: generateStaticParams 実行後の fetch 呼び出し回数を確認する
+    // Then: 0 回（ローカルファイルのみで完結する）
+    assert.equal(fetchCalls, 0)
+  })
+
+  it('generateStaticParams / getBlogArticle が関数としてエクスポートされている', () => {
+    assert.equal(typeof generateStaticParams, 'function')
+    assert.equal(typeof getBlogArticle, 'function')
+  })
+
+  it('generateStaticParams は { slug } の配列を返す（ローカル生成・fetch しない）', () => {
+    // Given: 外部 API に依存しないローカル実装
+    // When: generateStaticParams を呼ぶ
+    // Then: { slug: string } の配列が返る（fetch 依存だと localhost 接続失敗で throw する）
+    assert.ok(Array.isArray(params))
+    assert.ok(params.length > 0)
+    for (const p of params) {
+      assert.equal(typeof p.slug, 'string')
+      assert.deepEqual(Object.keys(p), ['slug'])
+    }
+  })
+
+  it('generateStaticParams は限定公開記事を含まない（従来挙動と一致）', () => {
+    // Given: 従来は /blog/（getAllPosts 相当）を fetch し限定公開を除外していた
+    // When: ローカル生成した静的パラメータの slug 集合を確認する
+    // Then: 公開記事の slug 集合と完全一致する（限定公開のみ欠落）
+    const actual = new Set(params.map((p) => p.slug))
+    const expected = new Set(readPublishedSlugs())
+    assert.deepEqual(actual, expected)
+  })
+
+  it('getBlogArticle は実在 slug の本文付き記事をローカルから返す', async () => {
+    // Given: 公開記事の slug
+    // When: getBlogArticle を呼ぶ
+    // Then: slug/title/content を持つ記事が返る
+    const slug = readPublishedSlugs()[0]
+    const article = await getBlogArticle(slug)
+    assert.equal(article.slug, slug)
+    assert.equal(typeof article.title, 'string')
+    assert.equal(typeof article.content, 'string')
+  })
+
+  it('getBlogArticle は存在しない slug で reject する', async () => {
+    // Given: 存在しない slug
+    // When: getBlogArticle を呼ぶ
+    // Then: エラーになる（壊れた API への fetch ではなくローカル判定）
+    await assert.rejects(() =>
+      getBlogArticle('__this_slug_does_not_exist_157__'),
+    )
+  })
+})

--- a/src/app/(pages)/blog/[slug]/page.server.tsx
+++ b/src/app/(pages)/blog/[slug]/page.server.tsx
@@ -1,46 +1,16 @@
-import { Post } from '@/types/posts'
+import { getAllPostsMeta, getPostBySlug } from '@/app/api/utils/getPostData'
 
-// Server-side uses API_URL (absolute), fallback to localhost
-const getServerApiUrl = () =>
-  process.env.API_URL || 'http://localhost:3000/my_site/api'
-
-// SSG
+// SSG: 静的パラメータはローカルの記事（src/posts/*.mdx）から生成する。
+// 外部 API への fetch をやめ、API 障害・URL 変更でビルドが落ちる依存を排除する（Issue #157）。
+// getAllPostsMeta は限定公開を除外するため、従来の /blog/ fetch と同じ公開記事集合になる。
 export async function generateStaticParams() {
-  const apiUrl = getServerApiUrl()
-  try {
-    const res = await fetch(`${apiUrl}/blog/`, {
-      cache: 'force-cache',
-    })
-    if (!res.ok) {
-      const errorText = await res.text()
-      throw new Error(`Failed to fetch data from ${apiUrl}/blog/: ${errorText}`)
-    }
-    const blogData = await res.json()
-    return blogData.map((blog: Post) => ({
-      slug: blog.slug,
-    }))
-  } catch (error) {
-    console.error('Error fetching blog data:', error)
-    throw new Error('Failed to fetch blog data')
-  }
+  const posts = await getAllPostsMeta()
+  return posts.map((post) => ({
+    slug: post.slug,
+  }))
 }
 
+// 記事本文もローカルから直接読み込む（ビルド時のリモート依存なし）。
 export const getBlogArticle = async (slug: string) => {
-  const apiUrl = getServerApiUrl()
-  try {
-    const res = await fetch(`${apiUrl}/blog/${slug}`, {
-      cache: 'force-cache',
-    })
-    if (!res.ok) {
-      const errorText = await res.text()
-      throw new Error(
-        `Failed to fetch data from ${apiUrl}/blog/${slug}: ${errorText}`,
-      )
-    }
-    const blogArticle = await res.json()
-    return blogArticle
-  } catch (error) {
-    console.error('Error fetching blog article:', error)
-    throw new Error('Failed to fetch blog article')
-  }
+  return await getPostBySlug(slug)
 }

--- a/src/app/(pages)/blog/[slug]/page.tsx
+++ b/src/app/(pages)/blog/[slug]/page.tsx
@@ -3,6 +3,10 @@ import ArticleContent from '@/app/components/templates/ArticleContent'
 import { Metadata } from 'next'
 import { getBlogArticle } from './page.server'
 
+// 静的書き出し（output: export）で [slug] を事前生成するため、route セグメントから
+// generateStaticParams を公開する（Next は page.server.tsx 側の export を拾わない）。
+export { generateStaticParams } from './page.server'
+
 export async function generateMetadata({
   params,
 }: {

--- a/src/app/(pages)/blog/page.tsx
+++ b/src/app/(pages)/blog/page.tsx
@@ -1,43 +1,8 @@
-'use client'
+import { getAllPostsMeta } from '@/app/api/utils/getPostData'
+import ArticleList from '@/app/components/templates/ArticleList'
 
-import AnimatedLine from '@/app/components/atoms/AnimatedLine'
-import PageFace from '@/app/components/organisms/PageFace'
-import dynamic from 'next/dynamic'
-import nextConfig from '../../../../next.config.mjs'
-import { useI18n } from '../../../i18n/context'
-import MaintenanceTemplate from '../../components/templates/MaintenanceTemplate'
+export default async function Blog() {
+  const posts = await getAllPostsMeta()
 
-const BASE_PATH = nextConfig.basePath || ''
-const public_flag = true
-
-const ArticleList = dynamic(
-  () => import('@/app/components/templates/ArticleList'),
-  { ssr: false },
-)
-
-export default function Blog() {
-  const { t } = useI18n()
-
-  return (
-    <>
-      {public_flag ? (
-        <>
-          <section>
-            <PageFace title={t.blog.title} subtitle="" mainMessage={<></>} />
-          </section>
-
-          <AnimatedLine />
-
-          <section>
-            <ArticleList />
-          </section>
-        </>
-      ) : (
-        <MaintenanceTemplate
-          title={t.blog.title}
-          imagePath={`${BASE_PATH}/images/cats/coming_soon.png`}
-        />
-      )}
-    </>
-  )
+  return <ArticleList initialPosts={posts} />
 }

--- a/src/app/api/utils/getPostData.test.mjs
+++ b/src/app/api/utils/getPostData.test.mjs
@@ -1,0 +1,180 @@
+// getAllPostsMeta() の振る舞い契約を検証する単体テスト（Issue #157 / TDD 先行）。
+//
+// 本リポジトリには JS テストランナー（jest/vitest 等）が未導入で、SoT は新規テスト基盤の
+// 立ち上げを不要としている。そのため Node v20 組み込みの `node:test` と、既存 devDependency の
+// `typescript` のみでテストを構成する（新規パッケージ追加なし）。
+//
+// 対象モジュール `getPostData.tsx` は TS/TSX かつ `process.cwd()/src/posts` を実ファイルとして
+// 読むため、ここでは実コードをインメモリで JS へトランスパイルして動的 import し、実在の記事
+// （src/posts/*.mdx）を fixtures として契約の不変条件を検証する。
+//
+// 実行: プロジェクトルートで `node --test src/app/api/utils/getPostData.test.mjs`
+// 実装前は `getAllPostsMeta` が未定義のため失敗する（TDD 上想定どおり）。
+
+import matter from 'gray-matter'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { after, before, describe, it } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const SOURCE_PATH = path.join(__dirname, 'getPostData.tsx')
+const BUILD_PATH = path.join(__dirname, '.getPostData.test-build.mjs')
+const POSTS_DIR = path.join(process.cwd(), 'src', 'posts')
+const LIMITED_TAG = '限定公開'
+
+// 実コード（getPostData.tsx）を JS へトランスパイルして import する。
+// gray-matter / fs / path の bare specifier を解決させるため、ビルド成果物は
+// ソースと同階層（node_modules を辿れる位置）へ書き出す。
+const loadModule = async () => {
+  const source = fs.readFileSync(SOURCE_PATH, 'utf8')
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+  })
+  fs.writeFileSync(BUILD_PATH, transpiled.outputText)
+  return import(`${BUILD_PATH}?t=${process.pid}`)
+}
+
+// fixtures から「限定公開を除いた」期待メタを gray-matter で独立に算出するオラクル。
+// getAllPostsMeta の実装ロジックに依存せず、期待値を別経路で求める。
+const readExpectedMeta = () => {
+  const files = fs
+    .readdirSync(POSTS_DIR)
+    .filter((name) => name.endsWith('.mdx'))
+  return files
+    .map((name) => {
+      const slug = name.replace(/\.mdx$/, '')
+      const { data } = matter(
+        fs.readFileSync(path.join(POSTS_DIR, name), 'utf8'),
+      )
+      return {
+        slug,
+        title: data.title,
+        date: data.date,
+        tags: data.tags || [],
+      }
+    })
+    .filter((meta) => !meta.tags.includes(LIMITED_TAG))
+}
+
+const parseDateMs = (value) => {
+  const time = new Date(value).getTime()
+  return Number.isNaN(time) ? new Date(0).getTime() : time
+}
+
+describe('getAllPostsMeta()', () => {
+  let getAllPostsMeta
+  let getAllPosts
+  let result
+
+  before(async () => {
+    const mod = await loadModule()
+    getAllPostsMeta = mod.getAllPostsMeta
+    getAllPosts = mod.getAllPosts
+    if (typeof getAllPostsMeta === 'function') {
+      result = await getAllPostsMeta()
+    }
+  })
+
+  after(() => {
+    if (fs.existsSync(BUILD_PATH)) fs.rmSync(BUILD_PATH)
+  })
+
+  it('関数としてエクスポートされている', () => {
+    // Given: getPostData モジュール
+    // When: getAllPostsMeta を参照する
+    // Then: 関数である（未実装なら失敗する）
+    assert.equal(typeof getAllPostsMeta, 'function')
+  })
+
+  it('配列を返す', async () => {
+    // Given: 実装済みの getAllPostsMeta
+    // When: 呼び出す
+    // Then: 配列が返る
+    assert.ok(Array.isArray(result))
+  })
+
+  it('限定公開タグの記事を除外する（件数が独立オラクルと一致）', () => {
+    // Given: src/posts の実 fixtures（限定公開を含む）
+    // When: getAllPostsMeta を呼ぶ
+    // Then: 限定公開を除いた件数と一致する
+    const expected = readExpectedMeta()
+    assert.equal(result.length, expected.length)
+  })
+
+  it('限定公開タグを持つ記事を1件も含まない', () => {
+    // Given: 返却された全メタ
+    // When: tags を走査する
+    // Then: どの記事も限定公開タグを持たない
+    const hasLimited = result.some((meta) =>
+      (meta.tags || []).includes(LIMITED_TAG),
+    )
+    assert.equal(hasLimited, false)
+  })
+
+  it('各メタは slug/title/date/tags のみを持ち content を含まない', () => {
+    // Given: 軽量メタの契約（content 非含有）
+    // When: 各要素のキー集合を確認する
+    // Then: 余分なキー（特に content）が無い
+    for (const meta of result) {
+      const keys = Object.keys(meta).sort()
+      assert.deepEqual(keys, ['date', 'slug', 'tags', 'title'])
+      assert.equal('content' in meta, false)
+    }
+  })
+
+  it('各メタの型が PostMeta 契約を満たす', () => {
+    // Given: PostMeta = { slug: string; title: string; date: string; tags: string[] }
+    // When: 各要素を検証する
+    // Then: 型が一致する
+    for (const meta of result) {
+      assert.equal(typeof meta.slug, 'string')
+      assert.equal(typeof meta.title, 'string')
+      assert.equal(typeof meta.date, 'string')
+      assert.ok(Array.isArray(meta.tags))
+    }
+  })
+
+  it('日付の新しい順（降順）にソート済みで返す', () => {
+    // Given: 返却された配列
+    // When: 隣接要素の日付を比較する
+    // Then: 常に前要素 >= 後要素（降順）
+    for (let i = 0; i < result.length - 1; i++) {
+      const current = parseDateMs(result[i].date)
+      const next = parseDateMs(result[i + 1].date)
+      assert.ok(
+        current >= next,
+        `インデックス ${i}（${result[i].date}）が ${i + 1}（${result[i + 1].date}）より新しくない`,
+      )
+    }
+  })
+
+  it('期待される slug 集合と一致する（限定公開のみ欠落）', () => {
+    // Given: 独立オラクルが算出した slug 集合
+    // When: 返却 slug 集合と比較する
+    // Then: 完全一致する（過不足なし）
+    const actual = new Set(result.map((meta) => meta.slug))
+    const expected = new Set(readExpectedMeta().map((meta) => meta.slug))
+    assert.deepEqual(actual, expected)
+  })
+
+  it('getAllPosts は残存し（後方互換）、件数が一致する', () => {
+    // Given: SoT は getAllPosts を「残す」と明記（api/blog・sitemap が依存）
+    // When: getAllPosts と getAllPostsMeta の件数を比較する
+    // Then: いずれも限定公開を除外しており件数が一致する
+    assert.equal(typeof getAllPosts, 'function')
+  })
+
+  it('getAllPostsMeta と getAllPosts は同じ件数（同一の除外規則）', async () => {
+    // Given: 双方とも限定公開を除外する
+    // When: 件数を比較する
+    // Then: 一致する
+    const full = await getAllPosts()
+    assert.equal(result.length, full.length)
+  })
+})

--- a/src/app/api/utils/getPostData.tsx
+++ b/src/app/api/utils/getPostData.tsx
@@ -1,3 +1,4 @@
+import type { PostMeta } from '@/types/posts'
 import fs from 'fs'
 import matter from 'gray-matter'
 import path from 'path'
@@ -10,6 +11,9 @@ interface PostData {
   content: string
   [key: string]: any // その他のメタデータに対応
 }
+
+// 一覧・サイトマップから除外する非公開記事のタグ
+const LIMITED_TAG = '限定公開'
 
 // posts ディレクトリのパスを取得
 const postsDirectoryPath = path.join(process.cwd(), 'src', 'posts')
@@ -47,8 +51,39 @@ export async function getAllPosts(): Promise<PostData[]> {
   // 限定公開タグを持つ記事を除外
   return posts.filter((post) => {
     const tags = post.tags || []
-    return !tags.includes('限定公開')
+    return !tags.includes(LIMITED_TAG)
   })
+}
+
+// 無効な日付は最小値（エポック）として扱い、ソートを安全にする
+const parseDateMs = (value: string): number => {
+  const time = new Date(value).getTime()
+  return Number.isNaN(time) ? 0 : time
+}
+
+// 一覧表示用の軽量メタ（本文 content を含まない）。
+// 限定公開を除外し、日付の新しい順に整列して返す。
+export async function getAllPostsMeta(): Promise<PostMeta[]> {
+  const fileNames = fs
+    .readdirSync(postsDirectoryPath)
+    .filter((name) => name.endsWith('.mdx'))
+
+  const metas: PostMeta[] = fileNames.map((name) => {
+    const slug = name.replace(/\.mdx$/, '')
+    const { data } = matter(
+      fs.readFileSync(path.join(postsDirectoryPath, name), 'utf8'),
+    )
+    return {
+      slug,
+      title: data.title,
+      date: data.date,
+      tags: data.tags || [],
+    }
+  })
+
+  return metas
+    .filter((meta) => !meta.tags.includes(LIMITED_TAG))
+    .sort((a, b) => parseDateMs(b.date) - parseDateMs(a.date))
 }
 
 export async function getAllSlugs() {

--- a/src/app/components/organisms/BlogGrid.tsx
+++ b/src/app/components/organisms/BlogGrid.tsx
@@ -1,48 +1,29 @@
 import BlogCard from '@/app/components/molecules/BlogCard'
 import { useI18n } from '@/i18n'
-import { useEffect, useState } from 'react'
+import { PostMeta } from '@/types/posts'
+import { useState } from 'react'
 
 interface BlogGridProps {
-  blogData: any
+  blogData: PostMeta[]
 }
 
 const BlogGrid: React.FC<BlogGridProps> = ({ blogData }) => {
   const { t } = useI18n()
   const [loadIndex, setLoadIndex] = useState(10)
-  const [isEmpty, setIsEmpty] = useState(false)
-  const [currentPost, setCurrentPost] = useState<any[]>([])
 
-  useEffect(() => {
-    if (blogData.length <= 10) {
-      setIsEmpty(true)
-    }
-  }, [blogData])
+  // blogData は getAllPostsMeta で日付降順に整列済み。state/useEffect を介すと
+  // 静的プリレンダー時に初期HTMLのグリッドが空になるため props から直接派生する。
+  const currentPost = blogData.slice(0, loadIndex)
+  const isEmpty = loadIndex >= blogData.length
 
   const displayMore = () => {
-    const newLoadIndex = loadIndex + 10
-    setLoadIndex(newLoadIndex)
-    if (newLoadIndex >= blogData.length) {
-      setIsEmpty(true)
-    }
+    setLoadIndex(loadIndex + 10)
   }
-
-  useEffect(() => {
-    // 日付の新しい順にソート
-    const sortedData = [...blogData].sort((a, b) => {
-      const dateA = new Date(a.date).getTime()
-      const dateB = new Date(b.date).getTime()
-      return dateB - dateA
-    })
-
-    // 現在の表示件数分のデータを取得
-    const currentData = sortedData.slice(0, loadIndex)
-    setCurrentPost(currentData)
-  }, [blogData, loadIndex])
 
   return (
     <>
       <div className="grid auto-rows-fr grid-cols-1 gap-6 md:grid-cols-2">
-        {currentPost.map((post: any) => (
+        {currentPost.map((post) => (
           <div key={post.slug} className="h-full">
             <BlogCard post={post} />
           </div>

--- a/src/app/components/templates/ArticleList.tsx
+++ b/src/app/components/templates/ArticleList.tsx
@@ -1,88 +1,33 @@
 'use client'
 
+import AnimatedLine from '@/app/components/atoms/AnimatedLine'
 import BlogGrid from '@/app/components/organisms/BlogGrid'
-import Sidebar from '@/app/components/templates/Sidebar'
-import { useRouter, useSearchParams } from 'next/navigation'
-import React, { useEffect, useState } from 'react'
-import { FiRefreshCw } from 'react-icons/fi'
-
-import LoadingCircle from '@/app/components/atoms/LoadingCircle'
+import PageFace from '@/app/components/organisms/PageFace'
 import styles from '@/app/components/templates/ArticleContent.module.css'
+import MaintenanceTemplate from '@/app/components/templates/MaintenanceTemplate'
+import Sidebar from '@/app/components/templates/Sidebar'
 import { useI18n } from '@/i18n'
+import { PostMeta } from '@/types/posts'
+import { useRouter, useSearchParams } from 'next/navigation'
+import React, { Suspense } from 'react'
+import { FiRefreshCw } from 'react-icons/fi'
+import nextConfig from '../../../../next.config.mjs'
 
-const getBlogData = async () => {
-  const apiUrl =
-    process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/my_site/api'
-  try {
-    const res = await fetch(`${apiUrl}/blog/`, {
-      cache: 'force-cache',
-    })
-    const blogData = await res.json()
-    return blogData
-  } catch (error) {
-    console.error('Error fetching blog data:', error)
-    throw new Error('Failed to fetch blog data')
-  }
+const BASE_PATH = nextConfig.basePath || ''
+const public_flag = true
+
+interface ArticleListProps {
+  initialPosts: PostMeta[]
 }
 
-const parseDate = (dateString: string): Date => {
-  try {
-    const date = new Date(dateString)
-    if (isNaN(date.getTime())) {
-      console.error('Invalid date:', dateString)
-      return new Date(0) // 無効な日付の場合は最小値を返す
-    }
-    return date
-  } catch (error) {
-    console.error('Error parsing date:', dateString)
-    return new Date(0)
-  }
+interface PostListViewProps {
+  posts: PostMeta[]
+  selectedTag: string | null
 }
 
-const ArticleList: React.FC = () => {
+const PostListView: React.FC<PostListViewProps> = ({ posts, selectedTag }) => {
   const { t } = useI18n()
-  const [blogData, setBlogData] = useState<any[]>([])
-  const [filteredData, setFilteredData] = useState<any[]>([])
-  const [selectedTag, setSelectedTag] = useState<string | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const searchParams = useSearchParams()
-  const tagName = searchParams.get('tag')
   const router = useRouter()
-
-  useEffect(() => {
-    getBlogData().then((data) => {
-      // 日付の新しい順に並び替え（新しい配列を作成）
-      const sortedData = [...data].sort((a: any, b: any) => {
-        const dateA = parseDate(a.date)
-        const dateB = parseDate(b.date)
-        return dateB.getTime() - dateA.getTime()
-      })
-      setBlogData(sortedData)
-      setFilteredData(sortedData)
-      setIsLoading(false)
-    })
-  }, [])
-
-  useEffect(() => {
-    if (tagName) {
-      setSelectedTag(tagName)
-      const filtered = blogData.filter((post) => post.tags.includes(tagName))
-      setFilteredData(filtered)
-    } else {
-      setSelectedTag(null)
-      setFilteredData(blogData)
-    }
-  }, [tagName, blogData])
-
-  const resetFilter = () => {
-    setSelectedTag(null)
-    setFilteredData(blogData)
-    router.push('/blog')
-  }
-
-  if (isLoading) {
-    return <LoadingCircle isLoading={isLoading} />
-  }
 
   return (
     <div className="flex justify-center">
@@ -93,7 +38,7 @@ const ArticleList: React.FC = () => {
               <>
                 <div className="text-xl font-bold">『{selectedTag}』</div>
                 <button
-                  onClick={resetFilter}
+                  onClick={() => router.push('/blog')}
                   className="relative flex items-center rounded px-6 py-3 text-lg text-main-black transition-all duration-300 after:absolute after:bottom-0 after:left-0 after:h-[2px] after:w-0 after:bg-teal after:transition-all after:duration-300 hover:after:w-full dark:text-night-white dark:after:bg-night-teal"
                 >
                   {t.blog.all}
@@ -104,13 +49,56 @@ const ArticleList: React.FC = () => {
               <div className="py-3 text-xl font-bold">{t.blog.all}</div>
             )}
           </div>
-          <BlogGrid blogData={filteredData} />
+          <BlogGrid blogData={posts} />
         </div>
         <div className="mt-16 flex-grow lg:ml-10">
           <Sidebar SidebarComponents={[]} />
         </div>
       </div>
     </div>
+  )
+}
+
+// useSearchParams は静的書き出しで <Suspense> 境界が必須のため、
+// タグ絞り込みはこの子コンポーネントに隔離する。
+const FilterablePostList: React.FC<ArticleListProps> = ({ initialPosts }) => {
+  const searchParams = useSearchParams()
+  const selectedTag = searchParams.get('tag')
+  const posts = selectedTag
+    ? initialPosts.filter((post) => post.tags.includes(selectedTag))
+    : initialPosts
+
+  return <PostListView posts={posts} selectedTag={selectedTag} />
+}
+
+const ArticleList: React.FC<ArticleListProps> = ({ initialPosts }) => {
+  const { t } = useI18n()
+
+  if (!public_flag) {
+    return (
+      <MaintenanceTemplate
+        title={t.blog.title}
+        imagePath={`${BASE_PATH}/images/cats/coming_soon.png`}
+      />
+    )
+  }
+
+  return (
+    <>
+      <section>
+        <PageFace title={t.blog.title} subtitle="" mainMessage={<></>} />
+      </section>
+
+      <AnimatedLine />
+
+      <section>
+        <Suspense
+          fallback={<PostListView posts={initialPosts} selectedTag={null} />}
+        >
+          <FilterablePostList initialPosts={initialPosts} />
+        </Suspense>
+      </section>
+    </>
   )
 }
 

--- a/src/types/posts.ts
+++ b/src/types/posts.ts
@@ -5,3 +5,10 @@ export type Post = {
   tags: string[]
   content: string
 }
+
+export type PostMeta = {
+  slug: string
+  title: string
+  date: string
+  tags: string[]
+}


### PR DESCRIPTION
## 概要
GitHub Issue #157「GitHub Pages(静的書き出し)がVercelホストAPIにビルド時依存しており壊れやすい」を takt（default workflow: テスト先行）で実装。

## 概要
GitHub Pages（静的書き出し）が Vercel ホストの API にビルド時依存している。`nextjs.yml` が `NEXT_PUBLIC_API_URL` を別ホスト（`my-site-nine-opal.vercel.app`）に固定し、`page.server` の `generateStaticParams` がビルド時にその API を fetch。API 側が落ちる / URL が変わるとビルド失敗で全サイトがデプロイ不能になる。

## 根拠
- `.github/workflows/nextjs.yml:88`
- `src/app/(pages)/blog/[slug]/page.server.tsx:9-19,28-34`

## 改善案
- [ ] ビルド時の slug 列挙はリモート API でなくローカルの `getAllSlugs()` を直接利用
- [ ] 外部 URL のハードコードをやめ Secret / 変数化、フォールバックも整備
- [ ] デプロイ構成（GitHub Pages か Vercel か）を一本化しドキュメント更新

工数: M

※ ブログ表示速度（#8）とも関連。ビルド時のリモート fetch 依存を切ると安定性・ビルド時間の改善が見込める。

---
Workflow `default` completed successfully.

Closes #157

🤖 Generated with takt + Claude Code