### PR TITLE
[#154] og-fetch のSSRF対策

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "prettier": "^3.3.3",
         "prettier-plugin-organize-imports": "^4.0.0",
         "tailwindcss": "^3.4.10",
+        "tsx": "^4.22.4",
         "typescript": "^5"
       }
     },
@@ -204,6 +205,448 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3254,6 +3697,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -9345,6 +9830,25 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel-rat": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "prettier --write \"src/**/*.{ts,tsx}\" && next build",
     "start": "next start",
     "start:api": "next dev -p 3001",
+    "test": "node --import tsx --test $(find src -name '*.test.ts')",
     "lint": "run-p -l -c --aggregate-output lint:*",
     "lint:eslint": "eslint .",
     "lint:prettier": "prettier --check .",
@@ -72,6 +73,7 @@
     "prettier": "^3.3.3",
     "prettier-plugin-organize-imports": "^4.0.0",
     "tailwindcss": "^3.4.10",
+    "tsx": "^4.22.4",
     "typescript": "^5"
   },
   "type": "module"

--- a/src/app/api/og-fetch/route.tsx
+++ b/src/app/api/og-fetch/route.tsx
@@ -1,3 +1,7 @@
+import {
+  assertPublicUrl,
+  UnsafeUrlError,
+} from '@/app/api/utils/validatePublicUrl'
 import { NextRequest, NextResponse } from 'next/server'
 import ogs from 'open-graph-scraper'
 
@@ -12,7 +16,17 @@ export const GET = async (req: NextRequest) => {
       return NextResponse.json({ error: 'Invalid URL' }, { status: 400 })
     }
 
-    const { result, error } = await ogs({ url })
+    // SSRF 対策: http/https のみ許可し、プライベート/メタデータ宛先を拒否
+    try {
+      await assertPublicUrl(url)
+    } catch (e) {
+      if (e instanceof UnsafeUrlError) {
+        return NextResponse.json({ error: e.message }, { status: 400 })
+      }
+      throw e
+    }
+
+    const { result, error } = await ogs({ url, timeout: 5 })
     if (error) {
       return NextResponse.json(
         { error: 'Failed to fetch Open Graph data' },

--- a/src/app/api/og-fetch/route.tsx
+++ b/src/app/api/og-fetch/route.tsx
@@ -1,5 +1,6 @@
 import {
   assertPublicUrl,
+  createSafeDispatcher,
   UnsafeUrlError,
 } from '@/app/api/utils/validatePublicUrl'
 import { NextRequest, NextResponse } from 'next/server'
@@ -26,7 +27,13 @@ export const GET = async (req: NextRequest) => {
       throw e
     }
 
-    const { result, error } = await ogs({ url, timeout: 5 })
+    // 接続層でも検証: リダイレクト先や DNS リバインディングによる
+    // プライベート宛先到達を、TCP 接続が確立する前にブロックする
+    const { result, error } = await ogs({
+      url,
+      timeout: 5,
+      fetchOptions: { dispatcher: createSafeDispatcher() },
+    })
     if (error) {
       return NextResponse.json(
         { error: 'Failed to fetch Open Graph data' },

--- a/src/app/api/utils/validatePublicUrl.test.ts
+++ b/src/app/api/utils/validatePublicUrl.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict'
+import http from 'node:http'
+import { test } from 'node:test'
+import { fetch } from 'undici'
+import {
+  assertPublicUrl,
+  createSafeDispatcher,
+  isPrivateIp,
+  UnsafeUrlError,
+} from './validatePublicUrl'
+
+test('isPrivateIp: プライベート/予約 IPv4 をブロック', () => {
+  for (const ip of [
+    '127.0.0.1',
+    '10.0.0.5',
+    '169.254.169.254', // クラウドメタデータ
+    '172.16.0.1',
+    '192.168.1.1',
+    '100.64.0.1', // CGNAT
+    '0.0.0.0',
+  ]) {
+    assert.equal(isPrivateIp(ip), true, `${ip} は private 判定されるべき`)
+  }
+})
+
+test('isPrivateIp: パブリック IPv4 は許可', () => {
+  for (const ip of ['8.8.8.8', '1.1.1.1', '93.184.216.34']) {
+    assert.equal(isPrivateIp(ip), false, `${ip} は public 判定されるべき`)
+  }
+})
+
+test('isPrivateIp: IPv6 のループバック/ULA/リンクローカル/マルチキャスト/サイトローカルをブロック', () => {
+  for (const ip of [
+    '::1',
+    'fc00::1',
+    'fd12::1',
+    'fe80::1',
+    'ff02::1', // マルチキャスト
+    'fec0::1', // 廃止サイトローカル
+    '::ffff:127.0.0.1', // IPv4-mapped
+  ]) {
+    assert.equal(isPrivateIp(ip), true, `${ip} は private 判定されるべき`)
+  }
+})
+
+test('assertPublicUrl: http/https 以外のスキームを拒否', async () => {
+  await assert.rejects(
+    () => assertPublicUrl('file:///etc/passwd'),
+    UnsafeUrlError,
+  )
+  await assert.rejects(
+    () => assertPublicUrl('ftp://example.com/'),
+    UnsafeUrlError,
+  )
+})
+
+test('assertPublicUrl: IP リテラルのプライベート宛先を拒否', async () => {
+  await assert.rejects(
+    () => assertPublicUrl('http://169.254.169.254/latest/meta-data/'),
+    UnsafeUrlError,
+  )
+  await assert.rejects(() => assertPublicUrl('http://[::1]/'), UnsafeUrlError)
+})
+
+test('safe dispatcher: IP リテラルのループバック宛先を接続時にブロック（リダイレクト先対策）', async () => {
+  const dispatcher = createSafeDispatcher()
+  const server = http.createServer((_q, s) => s.end('SECRET'))
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', () => r()))
+  const port = (server.address() as { port: number }).port
+  try {
+    await assert.rejects(
+      fetch(`http://127.0.0.1:${port}/`, { dispatcher }),
+      'ループバック宛先は拒否されるべき',
+    )
+  } finally {
+    server.close()
+  }
+})
+
+test('safe dispatcher: プライベートに名前解決されるホストを接続時にブロック（リダイレクト先対策）', async () => {
+  const dispatcher = createSafeDispatcher()
+  const server = http.createServer((_q, s) => s.end('SECRET'))
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', () => r()))
+  const port = (server.address() as { port: number }).port
+  try {
+    // localhost は 127.0.0.1 に解決される → safeLookup がブロックするはず
+    await assert.rejects(
+      fetch(`http://localhost:${port}/`, { dispatcher }),
+      'localhost は private に解決されるため拒否されるべき',
+    )
+  } finally {
+    server.close()
+  }
+})

--- a/src/app/api/utils/validatePublicUrl.ts
+++ b/src/app/api/utils/validatePublicUrl.ts
@@ -1,15 +1,15 @@
 import dns from 'dns'
 import net from 'net'
+import { Agent, buildConnector } from 'undici'
 
 /**
  * SSRF 対策: 外部公開してよい URL かを検証するユーティリティ。
  *
- * - スキームは http / https のみ許可
- * - ホスト名を名前解決し、プライベート / ループバック / リンクローカル /
- *   クラウドメタデータ（169.254.169.254 等）に解決される宛先を拒否
- *
- * 注意: DNS リバインディング（解決後に IP が変わる攻撃）までは完全に防げない。
- * 個人サイトの OG 取得用途として現実的な多層防御に留める。
+ * 多層防御:
+ * 1. assertPublicUrl … スキームを http/https に限定し、初回 URL の宛先を検証
+ * 2. createSafeDispatcher … 実際に TCP 接続する直前に解決先 IP を検証する
+ *    undici Agent。リダイレクト先・DNS リバインディングも接続層でブロックする
+ *    （初回 URL だけ検証しても fetch がリダイレクトを追従するため）。
  */
 
 export class UnsafeUrlError extends Error {
@@ -65,11 +65,16 @@ function isPrivateIpv6(ip: string): boolean {
     addr.startsWith('fe8') || // リンクローカル fe80::/10
     addr.startsWith('fe9') ||
     addr.startsWith('fea') ||
-    addr.startsWith('feb')
+    addr.startsWith('feb') ||
+    addr.startsWith('fec') || // 廃止サイトローカル fec0::/10
+    addr.startsWith('fed') ||
+    addr.startsWith('fee') ||
+    addr.startsWith('fef') ||
+    addr.startsWith('ff') // マルチキャスト ff00::/8
   )
 }
 
-function isPrivateIp(ip: string): boolean {
+export function isPrivateIp(ip: string): boolean {
   const type = net.isIP(ip)
   if (type === 4) return isPrivateIpv4(ip)
   if (type === 6) return isPrivateIpv6(ip)
@@ -122,4 +127,66 @@ export async function assertPublicUrl(rawUrl: string): Promise<URL> {
   }
 
   return parsed
+}
+
+/**
+ * 名前解決の結果がプライベート宛先なら接続を失敗させる dns.lookup 互換関数。
+ * undici の connector に渡され、ホスト名指定の接続（リダイレクト先含む）を守る。
+ */
+function safeLookup(
+  hostname: string,
+  options: dns.LookupOneOptions | dns.LookupAllOptions,
+  callback: (
+    err: NodeJS.ErrnoException | null,
+    address: string | dns.LookupAddress[],
+    family?: number,
+  ) => void,
+): void {
+  dns.lookup(hostname, { ...options, all: true }, (err, addresses) => {
+    if (err) {
+      callback(err, '', undefined)
+      return
+    }
+    for (const { address } of addresses) {
+      if (isPrivateIp(address)) {
+        callback(
+          new UnsafeUrlError(`Blocked private address: ${address}`),
+          '',
+          undefined,
+        )
+        return
+      }
+    }
+    if ((options as dns.LookupAllOptions).all) {
+      callback(null, addresses)
+    } else {
+      callback(null, addresses[0].address, addresses[0].family)
+    }
+  })
+}
+
+/**
+ * SSRF を接続層で防ぐ undici Agent を生成する。
+ *
+ * - ホスト名指定の接続は safeLookup で解決先 IP を検証
+ * - IP リテラル指定の接続（リダイレクト先が生 IP の場合など、lookup を経由しない）
+ *   は接続関数側で直接検証
+ *
+ * これにより初回 URL だけでなく、リダイレクト先や DNS リバインディングによる
+ * プライベート宛先到達も接続が確立する前にブロックされる。
+ */
+export function createSafeDispatcher(): Agent {
+  const baseConnector = buildConnector({ lookup: safeLookup })
+  return new Agent({
+    connect: (opts, cb) => {
+      if (net.isIP(opts.hostname) && isPrivateIp(opts.hostname)) {
+        cb(
+          new UnsafeUrlError(`Blocked private address: ${opts.hostname}`),
+          null,
+        )
+        return
+      }
+      baseConnector(opts, cb)
+    },
+  })
 }

--- a/src/app/api/utils/validatePublicUrl.ts
+++ b/src/app/api/utils/validatePublicUrl.ts
@@ -1,0 +1,125 @@
+import dns from 'dns'
+import net from 'net'
+
+/**
+ * SSRF 対策: 外部公開してよい URL かを検証するユーティリティ。
+ *
+ * - スキームは http / https のみ許可
+ * - ホスト名を名前解決し、プライベート / ループバック / リンクローカル /
+ *   クラウドメタデータ（169.254.169.254 等）に解決される宛先を拒否
+ *
+ * 注意: DNS リバインディング（解決後に IP が変わる攻撃）までは完全に防げない。
+ * 個人サイトの OG 取得用途として現実的な多層防御に留める。
+ */
+
+export class UnsafeUrlError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'UnsafeUrlError'
+  }
+}
+
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:'])
+
+// IPv4 を 32bit 整数へ変換
+function ipv4ToInt(ip: string): number {
+  return (
+    ip.split('.').reduce((acc, octet) => (acc << 8) + Number(octet), 0) >>> 0
+  )
+}
+
+function isPrivateIpv4(ip: string): boolean {
+  const n = ipv4ToInt(ip)
+  const inRange = (base: string, bits: number) =>
+    n >>> (32 - bits) === ipv4ToInt(base) >>> (32 - bits)
+
+  return (
+    inRange('0.0.0.0', 8) || // 現在のネットワーク / 未指定
+    inRange('10.0.0.0', 8) || // プライベート
+    inRange('100.64.0.0', 10) || // CGNAT
+    inRange('127.0.0.0', 8) || // ループバック
+    inRange('169.254.0.0', 16) || // リンクローカル（メタデータ 169.254.169.254 含む）
+    inRange('172.16.0.0', 12) || // プライベート
+    inRange('192.0.0.0', 24) || // IETF プロトコル割当
+    inRange('192.168.0.0', 16) || // プライベート
+    inRange('198.18.0.0', 15) || // ベンチマーク
+    inRange('224.0.0.0', 4) || // マルチキャスト
+    inRange('240.0.0.0', 4) // 予約
+  )
+}
+
+function isPrivateIpv6(ip: string): boolean {
+  const addr = ip.toLowerCase()
+
+  // IPv4-mapped (::ffff:a.b.c.d) は埋め込み IPv4 として判定
+  const mapped = addr.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/)
+  if (mapped) {
+    return isPrivateIpv4(mapped[1])
+  }
+
+  return (
+    addr === '::' || // 未指定
+    addr === '::1' || // ループバック
+    addr.startsWith('fc') || // ユニークローカル fc00::/7
+    addr.startsWith('fd') ||
+    addr.startsWith('fe8') || // リンクローカル fe80::/10
+    addr.startsWith('fe9') ||
+    addr.startsWith('fea') ||
+    addr.startsWith('feb')
+  )
+}
+
+function isPrivateIp(ip: string): boolean {
+  const type = net.isIP(ip)
+  if (type === 4) return isPrivateIpv4(ip)
+  if (type === 6) return isPrivateIpv6(ip)
+  // 判定不能な値は安全側に倒して拒否
+  return true
+}
+
+/**
+ * URL が外部取得して安全な公開ホストを指しているか検証する。
+ * 問題があれば UnsafeUrlError を throw する。
+ */
+export async function assertPublicUrl(rawUrl: string): Promise<URL> {
+  let parsed: URL
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    throw new UnsafeUrlError('Invalid URL')
+  }
+
+  if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
+    throw new UnsafeUrlError('Only http and https URLs are allowed')
+  }
+
+  const hostname = parsed.hostname
+
+  // ホスト名がそのまま IP リテラルの場合はそれを検証
+  if (net.isIP(hostname)) {
+    if (isPrivateIp(hostname)) {
+      throw new UnsafeUrlError('URL resolves to a private address')
+    }
+    return parsed
+  }
+
+  // 名前解決し、すべての解決先がパブリックであることを確認
+  let addresses: dns.LookupAddress[]
+  try {
+    addresses = await dns.promises.lookup(hostname, { all: true })
+  } catch {
+    throw new UnsafeUrlError('Failed to resolve hostname')
+  }
+
+  if (addresses.length === 0) {
+    throw new UnsafeUrlError('Failed to resolve hostname')
+  }
+
+  for (const { address } of addresses) {
+    if (isPrivateIp(address)) {
+      throw new UnsafeUrlError('URL resolves to a private address')
+    }
+  }
+
+  return parsed
+}


### PR DESCRIPTION
## 概要
GitHub Issue #154「API /og-fetch のSSRF脆弱性」を対応。

ユーザー入力の URL を無検証でサーバー取得していた `/api/og-fetch` に、サーバーサイドの検証を追加した。

## 変更内容
- `src/app/api/utils/validatePublicUrl.ts` を新規追加
  - URL スキームを `http`/`https` のみ許可（`new URL` でパース・`protocol` 検証）
  - ホスト名を名前解決し、解決先がプライベート/ループバック/リンクローカル/CGNAT/メタデータIP（`169.254.169.254` 等）の場合は拒否（IPv4 + IPv6、IPv4-mapped 含む）
  - IP リテラル直書きのホストも同様に検証
- `src/app/api/og-fetch/route.tsx`
  - 取得前に `assertPublicUrl` で検証。不正は 400 を返す
  - `ogs` に `timeout: 5`（秒）を設定

## 残課題（既知の限界）
- DNS リバインディング（解決後に IP が変わる攻撃）までは完全には防げない。OG取得用途として現実的な多層防御に留めている。必要なら許可ドメインの allowlist 化を別途検討。

## テスト
- IPv4 プライベート/メタデータ判定をスタンドアロンで検証（169.254.169.254 / 127.0.0.1 / 10.x / 172.16-31 / 100.64 / 0.0.0.0 をブロック、8.8.8.8 / 1.1.1.1 を許可）
- `tsc --noEmit` / `eslint` パス

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)