### PR TITLE
[#155] ブログ slug のパストラバーサル対策

### DIFF
--- a/src/app/api/blog/[slug]/route.tsx
+++ b/src/app/api/blog/[slug]/route.tsx
@@ -1,4 +1,8 @@
-import { getAllSlugs, getPostBySlug } from '@/app/api/utils/getPostData'
+import {
+  getAllSlugs,
+  getPostBySlug,
+  isValidSlug,
+} from '@/app/api/utils/getPostData'
 import { NextRequest, NextResponse } from 'next/server'
 
 const GET = async (
@@ -6,6 +10,12 @@ const GET = async (
   { params }: { params: { slug: string } },
 ) => {
   const { slug } = params
+
+  // パストラバーサル対策: 不正な slug は 404
+  if (!isValidSlug(slug)) {
+    return new NextResponse(null, { status: 404 })
+  }
+
   try {
     const blogArticle = await getPostBySlug(slug)
 

--- a/src/app/api/utils/getPostData.tsx
+++ b/src/app/api/utils/getPostData.tsx
@@ -14,6 +14,14 @@ interface PostData {
 // posts ディレクトリのパスを取得
 const postsDirectoryPath = path.join(process.cwd(), 'src', 'posts')
 
+// パストラバーサル対策: slug に許可する文字（英数字・ハイフン・アンダースコアのみ）
+const VALID_SLUG = /^[a-zA-Z0-9_-]+$/
+
+// slug が安全（パストラバーサルを含まない）かを判定
+export function isValidSlug(slug: string): boolean {
+  return VALID_SLUG.test(slug.replace(/\.mdx$/, ''))
+}
+
 // ディレクトリが存在しない場合に作成
 if (!fs.existsSync(postsDirectoryPath)) {
   fs.mkdirSync(postsDirectoryPath, { recursive: true })
@@ -21,6 +29,12 @@ if (!fs.existsSync(postsDirectoryPath)) {
 
 export async function getPostBySlug(slug: string): Promise<PostData> {
   const realSlug = slug.replace(/\.mdx$/, '')
+
+  // パストラバーサル対策: `../` や `/` を含む不正な slug を拒否
+  if (!isValidSlug(realSlug)) {
+    throw new Error(`Invalid slug: ${slug}`)
+  }
+
   const fullPath = path.join(postsDirectoryPath, `${realSlug}.mdx`)
 
   // ファイルが存在するか確認


### PR DESCRIPTION
## 概要
GitHub Issue #155「ブログAPI slug のパストラバーサル余地」を対応。

`slug` を未サニタイズで `path.join` に渡しており、`../` を含む slug で posts ディレクトリ外を読み取れるリスクがあった。

## 変更内容
- `src/app/api/utils/getPostData.tsx`
  - `^[a-zA-Z0-9_-]+$` で slug をバリデートする `isValidSlug` を追加
  - `getPostBySlug` 内で最下層の防御として不正 slug を拒否（全呼び出し元を保護）
- `src/app/api/blog/[slug]/route.tsx`
  - 不正な slug は早期に 404 を返す

## 影響確認
- 既存記事 24件のファイル名はすべて `^[a-zA-Z0-9_-]+$` に適合（破壊なし）
- `tsc --noEmit` / `eslint` パス

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)