### PR TITLE
[#164] 問い合わせFormのhoneypotが推測容易＋i18nの as any

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "prettier --write \"src/**/*.{ts,tsx}\" && next build",
     "start": "next start",
     "start:api": "next dev -p 3001",
-    "test": "node --import tsx --test $(find src -name '*.test.ts')",
+    "test": "node --import tsx --test $(find src \\( -name '*.test.ts' -o -name '*.test.tsx' \\))",
     "lint": "run-p -l -c --aggregate-output lint:*",
     "lint:eslint": "eslint .",
     "lint:prettier": "prettier --check .",

--- a/src/app/components/organisms/Form.test.tsx
+++ b/src/app/components/organisms/Form.test.tsx
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { I18nProvider } from '../../../i18n/context'
+import Form from './Form'
+
+// 一部のコンポーネントは React を import せず automatic JSX runtime を前提にしている。
+// tsx は JSX を classic な React.createElement に変換するため、グローバルに React を渡す。
+const globalScope = globalThis as Record<string, unknown>
+globalScope.React = React
+
+// useI18n は Provider を要求するので initialLocale を明示してSSR描画する。
+function renderForm(locale: 'ja' | 'en'): string {
+  return renderToStaticMarkup(
+    <I18nProvider initialLocale={locale}>
+      <Form />
+    </I18nProvider>,
+  )
+}
+
+test('Form: honeypot は name="wana" を使う', () => {
+  // Given/When: Form を描画する
+  const html = renderForm('ja')
+  // Then: honeypot 用の name="wana" を持つ
+  assert.match(html, /name="wana"/)
+})
+
+test('Form: 旧 honeypot 名 trap-column は残さない', () => {
+  // Given/When: Form を描画する
+  const html = renderForm('ja')
+  // Then: 推測容易な旧名 trap-column は撤去されている
+  assert.doesNotMatch(html, /trap-column/)
+})
+
+test('Form: honeypot は aria-hidden で支援技術から隠す', () => {
+  // Given/When: Form を描画する
+  const html = renderForm('ja')
+  // Then: honeypot ラッパに aria-hidden="true" が付与されている
+  assert.match(html, /aria-hidden="true"/)
+})
+
+test('Form: honeypot は autocomplete=off でブラウザ自動補完を抑止する', () => {
+  // Given/When: Form を描画する
+  const html = renderForm('ja')
+  // Then: autocomplete="off" が出力される（React の autoComplete は小文字属性に変換される）
+  assert.match(html, /autocomplete="off"/i)
+})
+
+test('Form: honeypot フィールドは hidden で視覚的に隠れている', () => {
+  // Given/When: Form を描画する
+  const html = renderForm('ja')
+  // Then: 視覚的に非表示のラッパ内に honeypot がある（人間には見えずボットだけが埋める）
+  assert.match(
+    html,
+    /class="hidden"[^>]*aria-hidden="true"|aria-hidden="true"[^>]*class="hidden"/,
+  )
+})

--- a/src/app/components/organisms/Form.tsx
+++ b/src/app/components/organisms/Form.tsx
@@ -4,6 +4,10 @@ import SubmitButton from '../atoms/SubmitButton'
 import InputLongText from '../molecules/InputLongText'
 import InputText from '../molecules/InputText'
 
+// honeypot フィールド名。人間には見えずボットだけが値を入れる想定。
+// この値が入った送信を弾けるかは ssgform 側のスパムフィルタ設定に依存する（設定は未確認）。
+const HONEYPOT_FIELD_NAME = 'wana'
+
 const Form: React.FC = () => {
   const { t } = useI18n()
 
@@ -13,8 +17,14 @@ const Form: React.FC = () => {
       method="post"
       className="mx-auto space-y-8 rounded-lg bg-white p-4 dark:bg-night-gray md:p-8"
     >
-      <div className="hidden">
-        <input type="text" name="trap-column" />
+      <div className="hidden" aria-hidden="true">
+        <input
+          type="text"
+          name={HONEYPOT_FIELD_NAME}
+          id={HONEYPOT_FIELD_NAME}
+          tabIndex={-1}
+          autoComplete="off"
+        />
       </div>
       <InputText
         label={t.contact.form.name}

--- a/src/app/components/organisms/MessageBoard.test.tsx
+++ b/src/app/components/organisms/MessageBoard.test.tsx
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { I18nProvider } from '../../../i18n/context'
+import { translations } from '../../../i18n/translations'
+import MessageBoard from './MessageBoard'
+
+// 一部のコンポーネントは React を import せず automatic JSX runtime を前提にしている。
+// tsx は JSX を classic な React.createElement に変換するため、グローバルに React を渡す。
+const globalScope = globalThis as Record<string, unknown>
+globalScope.React = React
+
+// `as any` 撤廃後も MessageBoard が翻訳キーを正しく解決して描画できることを保証する統合テスト。
+// MessageBoard + MessageData + translations + i18n context を横断する。
+function renderBoard(locale: 'ja' | 'en'): string {
+  return renderToStaticMarkup(
+    <I18nProvider initialLocale={locale}>
+      <MessageBoard />
+    </I18nProvider>,
+  )
+}
+
+test('MessageBoard: ja ロケールで announcement タイトルを描画する', () => {
+  // Given/When: 日本語で描画する
+  const html = renderBoard('ja')
+  // Then: items から解決したタイトルが本文に含まれる
+  assert.ok(
+    html.includes(translations.ja.announcements.items['2025-09-27'].title),
+  )
+})
+
+test('MessageBoard: en ロケールで announcement タイトルを描画する', () => {
+  // Given/When: 英語で描画する
+  const html = renderBoard('en')
+  // Then: items から解決した英語タイトルが本文に含まれる
+  assert.ok(
+    html.includes(translations.en.announcements.items['2025-09-27'].title),
+  )
+})
+
+test('MessageBoard: link を持つ announcement の linkText を描画する', () => {
+  // Given/When: 日本語で描画する
+  const html = renderBoard('ja')
+  // Then: link 付きお知らせの linkText（短歌）がリンク表示される
+  assert.ok(
+    html.includes(translations.ja.announcements.items['2025-09-27'].linkText),
+  )
+})
+
+test('MessageBoard: カテゴリ名を描画する', () => {
+  // Given/When: 日本語で描画する
+  const html = renderBoard('ja')
+  // Then: categoryKey から解決したカテゴリ名が含まれる
+  assert.ok(
+    html.includes(translations.ja.announcements.categories.notification),
+  )
+})

--- a/src/app/components/organisms/MessageBoard.tsx
+++ b/src/app/components/organisms/MessageBoard.tsx
@@ -27,7 +27,7 @@ const MessageBoard = () => {
                 </span>
               </p>
               <p className="m-0 mt-2 w-full text-base md:mt-0">
-                {(t.announcements.items as any)[announcement.titleKey]?.title}
+                {t.announcements.items[announcement.titleKey].title}
                 {announcement.link && (
                   <>
                     {' '}
@@ -36,9 +36,8 @@ const MessageBoard = () => {
                       className="text-teal underline dark:text-night-teal"
                     >
                       {
-                        (t.announcements.items as any)[
-                          announcement.link.textKey
-                        ]?.linkText
+                        t.announcements.items[announcement.link.textKey]
+                          .linkText
                       }
                     </a>
                   </>

--- a/src/app/components/organisms/MessageData.test.ts
+++ b/src/app/components/organisms/MessageData.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { translations } from '../../../i18n/translations'
+import { announcementsData } from './MessageData'
+
+const locales = ['ja', 'en'] as const
+
+test('MessageData: 全 titleKey が ja/en 両ロケールの items に存在する', () => {
+  // Given: 全お知らせデータ
+  for (const locale of locales) {
+    const items = translations[locale].announcements.items
+    for (const a of announcementsData) {
+      // When/Then: titleKey が両ロケールの items に存在し、title が文字列である
+      assert.ok(
+        items[a.titleKey],
+        `${locale}: titleKey "${a.titleKey}" が未定義`,
+      )
+      assert.equal(typeof items[a.titleKey].title, 'string')
+    }
+  }
+})
+
+test('MessageData: link を持つ全 textKey が ja/en 両ロケールの items に存在する', () => {
+  // Given: link を持つお知らせデータ
+  for (const locale of locales) {
+    const items = translations[locale].announcements.items
+    for (const a of announcementsData) {
+      if (!a.link) continue
+      // When/Then: textKey が両ロケールの items に存在し、linkText が文字列である
+      assert.ok(
+        items[a.link.textKey],
+        `${locale}: textKey "${a.link.textKey}" が未定義`,
+      )
+      assert.equal(typeof items[a.link.textKey].linkText, 'string')
+    }
+  }
+})

--- a/src/app/components/organisms/MessageData.ts
+++ b/src/app/components/organisms/MessageData.ts
@@ -1,12 +1,14 @@
+import type { AnnouncementItemKey } from '@/i18n'
+
 export interface AnnouncementLink {
   url: string
-  textKey: string
+  textKey: AnnouncementItemKey
 }
 
 export interface AnnouncementData {
   date: string
   categoryKey: 'blogUpdate' | 'notification'
-  titleKey: string
+  titleKey: AnnouncementItemKey
   link?: AnnouncementLink
 }
 

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -146,16 +146,21 @@ export type TranslationKeys = {
       blogUpdate: string
       notification: string
     }
-    items: {
-      '2025-09-27': { title: string; linkText: string }
-      '2025-08-20': { title: string; linkText: string }
-      '2025-04-22': { title: string; linkText: string }
-      '2025-04-21': { title: string; linkText: string }
-      '2025-04-01': { title: string; linkText: string }
-      // '2025-03-08-blog': { title: string; linkText: string };
-      [key: string]: { title: string; linkText: string }
-    }
+    items: AnnouncementItems
   }
 }
+
+export type AnnouncementItem = { title: string; linkText: string }
+
+// items のキーは有限 union とし、未定義キーをコンパイル時に検出する（index signature を持たせない）。
+export type AnnouncementItems = {
+  '2025-09-27': AnnouncementItem
+  '2025-08-20': AnnouncementItem
+  '2025-04-22': AnnouncementItem
+  '2025-04-21': AnnouncementItem
+  '2025-04-01': AnnouncementItem
+}
+
+export type AnnouncementItemKey = keyof AnnouncementItems
 
 export type Translations = Record<Locale, TranslationKeys>


### PR DESCRIPTION
## 概要
GitHub Issue #164「問い合わせFormのhoneypotが推測容易＋i18nの as any」を takt（default workflow: テスト先行）で実装。

## 概要
問い合わせ Form は ssgform 外部送信＋hidden honeypot のみで、フィールド名（`trap-column`）が推測容易でスパムが素通りしやすい。加えて `MessageBoard` でお知らせ参照に `as any` を使い、キー不整合がコンパイル時に検出できない。

## 根拠
- `src/app/components/organisms/Form.tsx:16-18`
- `src/app/components/organisms/MessageBoard.tsx:30,39`

## 改善案
- [ ] honeypot の name/id を目立たない命名に変更し `aria-hidden` + `autocomplete=off` を付与
- [ ] ssgform 側のスパムフィルタ設定を確認、必要ならクライアント側バリデーション追加
- [ ] `announcements.items` のキー型を厳密化して `as any` を撤廃

工数: S

---
Workflow `default` completed successfully.

Closes #164

🤖 Generated with takt + Claude Code