### PR TITLE
[#160] App Router に error/loading 境界がなくAPI障害時にクラッシュ表示

### DIFF
--- a/src/app/(pages)/blog/[slug]/loading.test.tsx
+++ b/src/app/(pages)/blog/[slug]/loading.test.tsx
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import Loading from './loading'
+
+// tsx は JSX を classic な React.createElement に変換するため、グローバルに React を渡す。
+const globalScope = globalThis as Record<string, unknown>
+globalScope.React = React
+
+test('blog/[slug]/loading: スケルトンが例外なく描画される', () => {
+  // Given/When/Then: Server Component の純粋スケルトンが SSR 描画で throw しない
+  assert.doesNotThrow(() => renderToStaticMarkup(<Loading />))
+})
+
+test('blog/[slug]/loading: animate-pulse のスケルトンプレースホルダを描画する', () => {
+  // Given/When: 記事本文の loading を描画する
+  const html = renderToStaticMarkup(<Loading />)
+  // Then: ローディング表現として animate-pulse が出力される
+  assert.match(html, /animate-pulse/)
+})
+
+test('blog/[slug]/loading: プレースホルダに CSS 生成されるテーマ色を用いる', () => {
+  // tailwind.config.ts が gray を単一文字列で上書きし gray-<数値> は CSS 未生成のため、
+  // 実在テーマ色を使い、未生成シェードでスケルトンが不可視化する回帰を防ぐ。
+  const html = renderToStaticMarkup(<Loading />)
+  assert.match(html, /bg-gray dark:bg-night-gray/)
+  assert.doesNotMatch(html, /bg-gray-\d/)
+})

--- a/src/app/(pages)/blog/[slug]/loading.tsx
+++ b/src/app/(pages)/blog/[slug]/loading.tsx
@@ -1,0 +1,18 @@
+// 記事本文のナビゲーション中に表示するスケルトン。
+// タイトルバーと本文行のプレースホルダを描画する。
+export default function Loading() {
+  return (
+    <div className="mx-auto flex w-full max-w-3xl animate-pulse flex-col gap-4">
+      <div className="h-8 w-2/3 rounded bg-gray dark:bg-night-gray" />
+      <div className="h-4 w-1/3 rounded bg-gray dark:bg-night-gray" />
+      <div className="mt-6 flex flex-col gap-3">
+        {Array.from({ length: 8 }, (_, index) => (
+          <div
+            key={index}
+            className="h-4 w-full rounded bg-gray dark:bg-night-gray"
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(pages)/blog/loading.test.tsx
+++ b/src/app/(pages)/blog/loading.test.tsx
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import Loading from './loading'
+
+// tsx は JSX を classic な React.createElement に変換するため、グローバルに React を渡す。
+const globalScope = globalThis as Record<string, unknown>
+globalScope.React = React
+
+test('blog/loading: スケルトンが例外なく描画される', () => {
+  // Given/When/Then: Server Component の純粋スケルトンが SSR 描画で throw しない
+  assert.doesNotThrow(() => renderToStaticMarkup(<Loading />))
+})
+
+test('blog/loading: animate-pulse のスケルトンプレースホルダを描画する', () => {
+  // Given/When: ブログ一覧の loading を描画する
+  const html = renderToStaticMarkup(<Loading />)
+  // Then: ローディング表現として animate-pulse が出力される
+  assert.match(html, /animate-pulse/)
+})
+
+test('blog/loading: プレースホルダに CSS 生成されるテーマ色を用いる', () => {
+  // tailwind.config.ts が gray を単一文字列で上書きし gray-<数値> は CSS 未生成のため、
+  // 実在テーマ色を使い、未生成シェードでスケルトンが不可視化する回帰を防ぐ。
+  const html = renderToStaticMarkup(<Loading />)
+  assert.match(html, /bg-gray dark:bg-night-gray/)
+  assert.doesNotMatch(html, /bg-gray-\d/)
+})

--- a/src/app/(pages)/blog/loading.tsx
+++ b/src/app/(pages)/blog/loading.tsx
@@ -1,0 +1,18 @@
+// ブログ一覧のナビゲーション中に表示するスケルトン。
+// BlogGrid のグリッド（grid-cols-1 md:grid-cols-2 gap-6）に合わせたカード型プレースホルダ。
+export default function Loading() {
+  return (
+    <div className="grid auto-rows-fr grid-cols-1 gap-6 md:grid-cols-2">
+      {Array.from({ length: 6 }, (_, index) => (
+        <div
+          key={index}
+          className="flex animate-pulse flex-col gap-4 rounded-lg bg-main-white p-4 dark:bg-night-black"
+        >
+          <div className="h-40 w-full rounded bg-gray dark:bg-night-gray" />
+          <div className="h-5 w-3/4 rounded bg-gray dark:bg-night-gray" />
+          <div className="h-4 w-1/2 rounded bg-gray dark:bg-night-gray" />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/app/components/templates/ErrorView.test.tsx
+++ b/src/app/components/templates/ErrorView.test.tsx
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import ErrorView from './ErrorView'
+
+// 一部のコンポーネントは React を import せず automatic JSX runtime を前提にしている。
+// tsx は JSX を classic な React.createElement に変換するため、グローバルに React を渡す。
+const globalScope = globalThis as Record<string, unknown>
+globalScope.React = React
+
+// ErrorView は context 非依存（props のみ）で設計される。
+// global-error.tsx は I18nProvider/ThemeProvider/Router context が存在しない crash path で使うため、
+// Provider を一切ラップせずに SSR 描画できることが設計契約。
+function renderErrorView(props: {
+  title: string
+  message: string
+  retryLabel: string
+}): string {
+  return renderToStaticMarkup(
+    <ErrorView
+      title={props.title}
+      message={props.message}
+      retryLabel={props.retryLabel}
+      onRetry={() => {}}
+    />,
+  )
+}
+
+test('ErrorView: title が描画される', () => {
+  // Given: 表示用の文言
+  // When: ErrorView を描画する
+  const html = renderErrorView({
+    title: 'エラーが発生しました',
+    message: 'メッセージ本文',
+    retryLabel: '再試行',
+  })
+  // Then: title 文言がマークアップに出力される
+  assert.match(html, /エラーが発生しました/)
+})
+
+test('ErrorView: message が描画される', () => {
+  // Given: 表示用の文言
+  // When: ErrorView を描画する
+  const html = renderErrorView({
+    title: 'タイトル',
+    message: 'ページの表示中に問題が発生しました。',
+    retryLabel: '再試行',
+  })
+  // Then: message 文言がマークアップに出力される
+  assert.match(html, /ページの表示中に問題が発生しました。/)
+})
+
+test('ErrorView: retryLabel が再試行ボタン内に描画される', () => {
+  // Given: 再試行ボタンのラベル
+  // When: ErrorView を描画する
+  const html = renderErrorView({
+    title: 'タイトル',
+    message: 'メッセージ本文',
+    retryLabel: 'もう一度試す',
+  })
+  // Then: <button> 要素が存在し、その内側にラベル文言がある
+  assert.match(html, /<button[^>]*>[\s\S]*もう一度試す[\s\S]*<\/button>/)
+})
+
+test('ErrorView: Provider 無しでも例外を投げず描画できる（context 非依存契約）', () => {
+  // Given: I18nProvider / ThemeProvider を一切ラップしない crash path 相当の環境
+  // When/Then: useI18n 等の context 依存があれば "must be used within a Provider" で throw する。
+  //            ErrorView が props のみで完結していれば例外なく描画できる。
+  assert.doesNotThrow(() => {
+    renderErrorView({
+      title: 'タイトル',
+      message: 'メッセージ本文',
+      retryLabel: '再試行',
+    })
+  })
+})
+
+test('ErrorView: 既存の猫画像アセットを表示する', () => {
+  // Given: 表示用の文言
+  // When: ErrorView を描画する
+  const html = renderErrorView({
+    title: 'タイトル',
+    message: 'メッセージ本文',
+    retryLabel: '再試行',
+  })
+  // Then: public/images/cats 配下の既存アセットを参照する
+  //       （next/image による URL エンコードや素の <img> 切替のどちらでもファイル名は残る）
+  assert.match(html, /(page_not_found|coming_soon)\.png/)
+})

--- a/src/app/components/templates/ErrorView.tsx
+++ b/src/app/components/templates/ErrorView.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import React from 'react'
+import nextConfig from '../../../../next.config.mjs'
+import PageFace from '../organisms/PageFace'
+
+const BASE_PATH = nextConfig.basePath || ''
+
+interface ErrorViewProps {
+  title: string
+  message: string
+  retryLabel: string
+  onRetry: () => void
+}
+
+// context 非依存（props のみ）。global-error.tsx は I18nProvider/ThemeProvider/Router
+// context が存在しない crash path で使うため、useI18n/useTheme/usePathname を使わない。
+// 画像は素の <img>。next/image はランタイム/loader 依存があり crash path での堅牢性を優先する。
+const ErrorView: React.FC<ErrorViewProps> = ({
+  title,
+  message,
+  retryLabel,
+  onRetry,
+}) => {
+  return (
+    <section>
+      <PageFace title={title} subtitle={message} />
+
+      <div className="mt-10 flex w-full justify-center">
+        <img
+          src={`${BASE_PATH}/images/cats/page_not_found.png`}
+          alt={title}
+          width={500}
+          height={500}
+          className="rounded-2xl"
+        />
+      </div>
+
+      <div className="mt-8 flex justify-center">
+        <button
+          type="button"
+          onClick={onRetry}
+          className="rounded-lg bg-main-black px-6 py-3 font-medium text-white transition-shadow hover:shadow-lg"
+        >
+          {retryLabel}
+        </button>
+      </div>
+    </section>
+  )
+}
+
+export default ErrorView

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { useI18n } from '@/i18n'
+import { useEffect } from 'react'
+import ErrorView from './components/templates/ErrorView'
+
+// 配下ページのレンダリング例外を捕捉する root エラー境界。
+// I18nProvider は layout.tsx → ClientWrapper → I18nProvider 配下にあるため利用可。
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  const { t } = useI18n()
+
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <ErrorView
+      title={t.errors.title}
+      message={t.errors.message}
+      retryLabel={t.errors.retry}
+      onRetry={reset}
+    />
+  )
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { defaultLocale } from '@/i18n/config'
+import { translations } from '@/i18n/translations'
+import { useEffect } from 'react'
+import 'tailwindcss/tailwind.css'
+import ErrorView from './components/templates/ErrorView'
+import './globals.css'
+
+// root レイアウト自体の例外・全境界を抜けた例外を捕捉する最終境界。
+// root layout を置換するため <html><body> と CSS import を自前で持つ。
+// I18nProvider/ThemeProvider は不在のため、固定言語（defaultLocale=ja）の
+// 静的翻訳オブジェクトを直接参照し、ライトテーマで描画する。
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  const errors = translations[defaultLocale].errors
+
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <html lang={defaultLocale}>
+      <body>
+        <ErrorView
+          title={errors.title}
+          message={errors.message}
+          retryLabel={errors.retry}
+          onRetry={reset}
+        />
+      </body>
+    </html>
+  )
+}

--- a/src/i18n/translations.test.ts
+++ b/src/i18n/translations.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { translations } from './translations'
+import type { Locale } from './types'
+
+// error.tsx は t.errors.{title,message,retry} を参照し、ErrorView へ渡す。
+// 型 Translations は ja/en 両方に同じ shape を要求するため、片側更新は型エラーになるが、
+// 実行時に「両言語で同じキーが非空で揃っている」ことをここで明示的に固定する（片側更新の防止）。
+const LOCALES: Locale[] = ['ja', 'en']
+const ERROR_KEYS = ['title', 'message', 'retry'] as const
+
+for (const locale of LOCALES) {
+  test(`translations[${locale}]: errors ブロックが存在する`, () => {
+    // Given: 当該ロケールの翻訳
+    const t = translations[locale]
+    // When/Then: errors ブロックが定義されている
+    assert.ok(t.errors, `translations.${locale}.errors が未定義`)
+  })
+
+  for (const key of ERROR_KEYS) {
+    test(`translations[${locale}]: errors.${key} が非空文字列`, () => {
+      // Given: 当該ロケールの errors ブロック
+      const value = translations[locale].errors[key]
+      // Then: 非空の文字列である（プレースホルダや欠落を許さない）
+      assert.equal(typeof value, 'string')
+      assert.ok(value.length > 0, `errors.${key} が空文字`)
+    })
+  }
+}
+
+test('translations: errors のキー集合が ja/en で一致する', () => {
+  // Given: 両ロケールの errors ブロック
+  const jaKeys = Object.keys(translations.ja.errors).sort()
+  const enKeys = Object.keys(translations.en.errors).sort()
+  // Then: キー集合が完全一致する（片側だけにキーがある状態を検出）
+  assert.deepEqual(jaKeys, enKeys)
+})

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -236,6 +236,12 @@ export const translations: Translations = {
         // },
       },
     },
+    errors: {
+      title: 'エラーが発生しました',
+      message:
+        'ページの表示中に問題が発生しました。お手数ですが再試行してください。',
+      retry: '再試行',
+    },
   },
   en: {
     common: {
@@ -478,6 +484,12 @@ export const translations: Translations = {
         //   linkText: 'Blog',
         // },
       },
+    },
+    errors: {
+      title: 'Something went wrong',
+      message:
+        'An error occurred while displaying this page. Please try again.',
+      retry: 'Retry',
     },
   },
 }

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -148,6 +148,11 @@ export type TranslationKeys = {
     }
     items: AnnouncementItems
   }
+  errors: {
+    title: string
+    message: string
+    retry: string
+  }
 }
 
 export type AnnouncementItem = { title: string; linkText: string }


### PR DESCRIPTION
## 概要
GitHub Issue #160「App Router に error/loading 境界がなくAPI障害時にクラッシュ表示」を takt（default workflow: テスト先行）で実装。

## 概要
App Router に `error.tsx` / `global-error.tsx` / `loading.tsx` が全ページに存在せず、`page.server` が fetch 失敗時に `throw` するため、ブログ等でランタイムエラーがそのままユーザーに露出する。

## 根拠
- `src/app/(pages)/blog/[slug]/page.server.tsx:33-34`（throw）
- `find src/app` で `error.tsx` / `loading.tsx` 0 件

## 改善案
- [ ] ルートに `app/global-error.tsx`、各セクションに `error.tsx` を追加
- [ ] データ取得系ルートに `loading.tsx` でスケルトン表示
- [ ] fetch 失敗時は throw でなくフォールバック UI を返す検討

工数: S

※ ブログ表示速度（#8）の体感改善にも寄与（loading スケルトンで初期表示を即時化）。

---
Workflow `default` completed successfully.

Closes #160

🤖 Generated with takt + Claude Code