### PR TITLE
[#198] Yomoyo紹介・サポート用LP（概要/スクショ/問い合わせ/規約リンク）を作成

### DIFF
--- a/src/app/yomoyo/page.test.tsx
+++ b/src/app/yomoyo/page.test.tsx
@@ -1,0 +1,141 @@
+// Yomoyo 紹介・サポート用 LP（src/app/yomoyo/page.tsx）の表示契約を固定する単体テスト
+// （Issue #198 / TDD 先行）。
+//
+// 計画（reports/plan.md）で確定した LP の振る舞いを検証する:
+//   - Server Component を renderToStaticMarkup で例外なく描画できる
+//   - metadata（title/description）を export する
+//   - 概要 / スクショ / 問い合わせ / 規約・ポリシーリンクの 4 セクションを含む
+//   - 内部リンク href は basePath 有無に依存しないよう部分一致で検証する
+//   - スクショ <img> の src には手動 BASE_PATH（/my_site）を付与する（next/link と異なる契約）
+//   - tailwind が未生成にする gray-<数値> を使わない（不可視化回帰の防止）
+//
+// 既存の BlogCard.test.tsx と同様、Node 組み込み node:test と
+// react-dom/server の renderToStaticMarkup のみで構成する（新規パッケージ無し）。
+// page は next/link に依存するため、resolve フックで素の <a> を返すモックへ
+// 張り替えてから動的 import する（AppRouter コンテキスト外での描画を安定させる）。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は page.tsx が未存在のため RED、実装後に GREEN になることを期待する。
+
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+// next/link は AppRouter コンテキストに依存するため、href と children のみを
+// 反映する素の <a> へ差し替える。これにより内部リンクの href を SSR markup で検証できる。
+// data: URL モジュールは bare specifier 'react' を解決できないため import せず、
+// テストが設定する globalThis.React（classic JSX runtime 用）を参照する
+// （BlogCard.test.tsx の navMock と同じ無 import パターン）。
+const linkMock =
+  'data:text/javascript,' +
+  encodeURIComponent(
+    "export default function Link(props){return React.createElement('a', {href: props.href}, props.children)}",
+  )
+
+const resolveHook = `
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === 'next/link') {
+    return { url: ${JSON.stringify(linkMock)}, shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}
+`
+register(
+  'data:text/javascript,' + encodeURIComponent(resolveHook),
+  import.meta.url,
+)
+
+// tsx は classic JSX runtime へ変換するため React をグローバルに渡す。
+;(globalThis as Record<string, unknown>).React = React
+
+type YomoyoPageComponent = React.FC
+let YomoyoPage: YomoyoPageComponent
+let metadata: { title?: unknown; description?: unknown }
+
+before(async () => {
+  const mod = await import('./page')
+  YomoyoPage = mod.default as unknown as YomoyoPageComponent
+  metadata = mod.metadata as { title?: unknown; description?: unknown }
+})
+
+test('yomoyo/page: LP が例外なく描画される', () => {
+  // Given/When/Then: Server Component の LP が SSR 描画で throw しない
+  assert.doesNotThrow(() => renderToStaticMarkup(<YomoyoPage />))
+})
+
+test('yomoyo/page: metadata に title と description を設定する', () => {
+  // Given: ランディング先として metadata を export する
+  // When/Then: title は文字列で「Yomoyo」を含み、description は非空文字列
+  assert.equal(typeof metadata.title, 'string')
+  assert.match(metadata.title as string, /Yomoyo/)
+  assert.equal(typeof metadata.description, 'string')
+  assert.ok((metadata.description as string).length > 0)
+})
+
+test('yomoyo/page: 概要セクションでアプリ名「Yomoyo」を見出しに表示する', () => {
+  // Given/When: LP を描画する
+  const html = renderToStaticMarkup(<YomoyoPage />)
+  // Then: アプリ名 Yomoyo が <h1> 見出しとして含まれる
+  assert.match(html, /<h1[^>]*>[^<]*Yomoyo/)
+})
+
+test('yomoyo/page: 概要セクションで読書記録アプリである旨を説明する', () => {
+  // Given/When: LP を描画する
+  const html = renderToStaticMarkup(<YomoyoPage />)
+  // Then: 事実ソース（terms/privacy）に基づき「読書記録」を含む
+  assert.ok(html.includes('読書記録'))
+})
+
+test('yomoyo/page: スクショ <img> の src に手動 BASE_PATH(/my_site) を付与する', () => {
+  // next/link は basePath を自動付与するが <img> は付与しないため、手動で
+  // BASE_PATH を前置する必要がある（計画の重要な設計判断）。
+  // Given/When: LP を描画する
+  const html = renderToStaticMarkup(<YomoyoPage />)
+  // Then: スクショ画像が basePath 配下の images/yomoyo を指す
+  assert.match(html, /<img[^>]+src="\/my_site\/images\/yomoyo\//)
+})
+
+test('yomoyo/page: スクショ <img> に alt 属性を付与する', () => {
+  // Given/When: LP を描画する
+  const html = renderToStaticMarkup(<YomoyoPage />)
+  // Then: 各スクショ画像に代替テキストが付く
+  assert.match(html, /<img[^>]+alt="[^"]+"/)
+})
+
+test('yomoyo/page: 問い合わせセクションで mailto 連絡先を表示する', () => {
+  // Given/When: LP を描画する
+  const html = renderToStaticMarkup(<YomoyoPage />)
+  // Then: 問い合わせ先メールへの mailto リンクを含む
+  assert.ok(html.includes('mailto:furugenmotoshig@gmail.com'))
+})
+
+test('yomoyo/page: 問い合わせセクションで運営者 Furugen Island を表示する', () => {
+  // Given/When: LP を描画する
+  const html = renderToStaticMarkup(<YomoyoPage />)
+  // Then: 運営者名を表示する
+  assert.ok(html.includes('Furugen Island'))
+})
+
+test('yomoyo/page: 利用規約 /yomoyo/terms への内部リンクを表示する', () => {
+  // basePath 付与の有無に依存しないよう href を部分一致で検証する。
+  // Given/When: LP を描画する
+  const html = renderToStaticMarkup(<YomoyoPage />)
+  // Then: 利用規約ページへのリンクを含む
+  assert.match(html, /href="[^"]*\/yomoyo\/terms"/)
+})
+
+test('yomoyo/page: プライバシーポリシー /yomoyo/privacy への内部リンクを表示する', () => {
+  // Given/When: LP を描画する
+  const html = renderToStaticMarkup(<YomoyoPage />)
+  // Then: プライバシーポリシーページへのリンクを含む
+  assert.match(html, /href="[^"]*\/yomoyo\/privacy"/)
+})
+
+test('yomoyo/page: 未生成の gray-<数値> ユーティリティを使わない', () => {
+  // tailwind.config.ts が gray を単一文字列で上書きし gray-<数値> は CSS 未生成のため、
+  // それらを使うと不可視化する。計画方針どおり gray-<数値> を含めないことを固定する。
+  const html = renderToStaticMarkup(<YomoyoPage />)
+  assert.doesNotMatch(html, /\bgray-\d/)
+})

--- a/src/app/yomoyo/page.tsx
+++ b/src/app/yomoyo/page.tsx
@@ -1,0 +1,110 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import nextConfig from '../../../next.config.mjs'
+
+const BASE_PATH = nextConfig.basePath || ''
+
+const CONTACT_EMAIL = 'furugenmotoshig@gmail.com'
+const OPERATOR_NAME = 'Furugen Island'
+const TERMS_PATH = '/yomoyo/terms'
+const PRIVACY_PATH = '/yomoyo/privacy'
+
+const FEATURES = [
+  '「読み終えた」本を登録して、自分だけの読書記録を残せます',
+  'フォロー中の利用者へ「読み終えた」を通知し、読書を共有できます',
+  'Google Books API による書籍検索と、バーコード（ISBN）スキャンで簡単登録',
+  'Google / Apple サインインに対応。フォロー・ブックマーク・プッシュ通知も利用できます',
+  'iOS / Android に対応。無料で利用できます（広告あり）',
+]
+
+const SCREENSHOTS = [
+  {
+    src: '/images/yomoyo/screenshot-01.png',
+    alt: '読み終えた本を登録するYomoyoの画面',
+  },
+  {
+    src: '/images/yomoyo/screenshot-02.png',
+    alt: 'フォロー中の利用者の読書記録を見るYomoyoの画面',
+  },
+  {
+    src: '/images/yomoyo/screenshot-03.png',
+    alt: 'バーコードで書籍を検索するYomoyoの画面',
+  },
+]
+
+const LINK_CLASS = 'text-teal-500 hover:underline dark:text-night-teal'
+
+export const metadata: Metadata = {
+  title: 'Yomoyo | 読書記録・共有アプリ',
+  description:
+    '読み終えた本を記録し、フォロー中の仲間と読書を共有できるモバイルアプリ「Yomoyo」の紹介・サポートページです。',
+}
+
+export default function YomoyoPage() {
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-12">
+      <section className="space-y-4">
+        <h1 className="text-3xl font-bold">Yomoyo</h1>
+        <p className="text-base leading-relaxed">
+          Yomoyo
+          は、読み終えた本を記録し、フォロー中の仲間と読書を共有できる読書記録・共有アプリです。
+        </p>
+        <ul className="list-disc space-y-2 pl-6 text-base leading-relaxed">
+          {FEATURES.map((feature) => (
+            <li key={feature}>{feature}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="mt-12 space-y-4">
+        <h2 className="text-xl font-semibold">スクリーンショット</h2>
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+          {SCREENSHOTS.map((screenshot) => (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              key={screenshot.src}
+              src={`${BASE_PATH}${screenshot.src}`}
+              alt={screenshot.alt}
+              className="w-full rounded-lg border border-teal-100 dark:border-night-gray"
+            />
+          ))}
+        </div>
+      </section>
+
+      <section className="mt-12 space-y-4">
+        <h2 className="text-xl font-semibold">お問い合わせ</h2>
+        <p className="text-base leading-relaxed">
+          ご質問・ご要望は、以下までお気軽にご連絡ください。
+        </p>
+        <ul className="list-disc space-y-1 pl-6">
+          <li>運営者: {OPERATOR_NAME}</li>
+          <li>
+            メールアドレス:
+            <a
+              href={`mailto:${CONTACT_EMAIL}`}
+              className={`ml-1 ${LINK_CLASS}`}
+            >
+              {CONTACT_EMAIL}
+            </a>
+          </li>
+        </ul>
+      </section>
+
+      <section className="mt-12 space-y-4">
+        <h2 className="text-xl font-semibold">規約・ポリシー</h2>
+        <ul className="list-disc space-y-1 pl-6">
+          <li>
+            <Link href={TERMS_PATH} className={LINK_CLASS}>
+              利用規約
+            </Link>
+          </li>
+          <li>
+            <Link href={PRIVACY_PATH} className={LINK_CLASS}>
+              プライバシーポリシー
+            </Link>
+          </li>
+        </ul>
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## 概要
GitHub Issue #198「Yomoyo紹介・サポート用LP（概要/スクショ/問い合わせ/規約リンク）を作成」を takt（default workflow: テスト先行）で実装。

## 背景
意図: Yomoyo紹介・サポート用LP（概要/スクショ/問い合わせ/規約リンク）を作成

（自動起案フォールバック: claude 出力をパースできず intent をそのまま使用）

---
Workflow `default` completed successfully.

Closes #198

🤖 Generated with takt + Claude Code