### PR TITLE
[#158] いいね/ハイスコアAPIにレート制限・改ざん対策がなく無制限に書込み可能

### DIFF
--- a/scripts/migrations/007_api_rate_limits.sql
+++ b/scripts/migrations/007_api_rate_limits.sql
@@ -1,0 +1,50 @@
+-- Issue #158: likes/highscore API のレート制限
+-- (IP, endpoint) 単位でウィンドウ内の書込み回数を記録・判定するテーブルと関数。
+
+-- 書込みリクエストの発生を記録するテーブル
+CREATE TABLE IF NOT EXISTS api_rate_limits (
+    id SERIAL PRIMARY KEY,
+    ip VARCHAR(45) NOT NULL, -- IPv4/IPv6対応
+    endpoint VARCHAR(64) NOT NULL,
+    requested_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- ウィンドウ内カウントを効率化するインデックス
+CREATE INDEX IF NOT EXISTS idx_api_rate_limits_lookup
+    ON api_rate_limits (ip, endpoint, requested_at DESC);
+
+-- レート制限を判定する関数。
+-- ウィンドウ内の書込み回数が max_requests 未満なら記録して TRUE（許可）を返し、
+-- 上限到達なら記録せず FALSE（拒否）を返す。
+CREATE OR REPLACE FUNCTION check_api_rate_limit(
+    ip_param VARCHAR(45),
+    endpoint_param VARCHAR(64),
+    max_requests INTEGER,
+    window_seconds INTEGER
+)
+RETURNS BOOLEAN AS $$
+DECLARE
+    window_start TIMESTAMP WITH TIME ZONE;
+    request_count INTEGER;
+BEGIN
+    window_start := NOW() - (window_seconds || ' seconds')::INTERVAL;
+
+    -- ウィンドウ外の古いレコードを掃除する
+    DELETE FROM api_rate_limits WHERE requested_at < window_start;
+
+    SELECT COUNT(*) INTO request_count
+    FROM api_rate_limits
+    WHERE ip = ip_param
+      AND endpoint = endpoint_param
+      AND requested_at >= window_start;
+
+    IF request_count >= max_requests THEN
+        RETURN FALSE;
+    END IF;
+
+    INSERT INTO api_rate_limits (ip, endpoint)
+    VALUES (ip_param, endpoint_param);
+
+    RETURN TRUE;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/app/api/highscore/route.test.mjs
+++ b/src/app/api/highscore/route.test.mjs
@@ -1,0 +1,253 @@
+// Issue #158 / TDD 先行: highscore POST の配線（検証 → レート制限 → 更新）を検証する結合テスト。
+//
+// 対象データフロー（計画 §4.3）: request.json → isValidScore → checkRateLimit → getHighScore/setHighScore。
+// 3 モジュール以上（route + scoreValidation + rateLimit + clientIp + octokit）を横断し、
+// 新ステータス 429 が既存 200/400/500 フローに合流するため結合テストを作成する。
+//
+// scoreValidation は実物をトランスパイルして通し（検証ロジックを end-to-end で検証）、
+// octokit・checkRateLimit・getClientIP は境界でモックする。既存 likes/bulk/route.test.mjs と
+// 同じ transpile + import 張り替え方式（node:test + typescript のみ、新規パッケージ無し）。
+//
+// 実行: `node --test src/app/api/highscore/route.test.mjs`
+// 実装前は route/scoreValidation/utils が未配線のため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { after, before, beforeEach, describe, it } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROUTE_SRC = path.join(__dirname, 'route.tsx')
+const SCORE_VALIDATION_SRC = path.join(__dirname, 'scoreValidation.ts')
+
+const ROUTE_BUILD = path.join(__dirname, '.route.test-build.mjs')
+const SCORE_VALIDATION_BUILD = path.join(__dirname, '.scoreValidation.test-build.mjs')
+const OCTOKIT_MOCK = path.join(__dirname, '.octokit.test-mock.mjs')
+const NEXT_MOCK = path.join(__dirname, '.next-server.test-mock.mjs')
+const CLIENTIP_MOCK = path.join(__dirname, '.clientIp.test-mock.mjs')
+const RATELIMIT_MOCK = path.join(__dirname, '.rateLimit.test-mock.mjs')
+
+const OCTOKIT_MOCK_CODE = `
+export class Octokit {
+  constructor() {
+    const fx = () => globalThis.__HIGHSCORE_FIXTURE__
+    this.issues = {
+      listForRepo: async () => {
+        const f = fx()
+        f.listForRepoCalls = (f.listForRepoCalls || 0) + 1
+        if (f.throwError) throw new Error('github boom')
+        return { data: f.issues }
+      },
+      create: async () => {
+        const f = fx()
+        f.createCalls = (f.createCalls || 0) + 1
+        return { data: { number: 999 } }
+      },
+      update: async (args) => {
+        const f = fx()
+        f.updateCalls = (f.updateCalls || 0) + 1
+        f.updateArgs = args
+        return { data: {} }
+      },
+    }
+  }
+}
+`
+
+const NEXT_MOCK_CODE = `
+export class NextRequest {}
+export const NextResponse = {
+  json(body, init) {
+    return {
+      status: (init && init.status) || 200,
+      async json() { return body },
+    }
+  },
+}
+`
+
+const CLIENTIP_MOCK_CODE = `
+export function getClientIP() { return '203.0.113.5' }
+`
+
+// checkRateLimit の戻り値をグローバル fixture から制御する。
+const RATELIMIT_MOCK_CODE = `
+export const RATE_LIMITS = {
+  likes: { max: 30, windowSeconds: 60 },
+  highscore: { max: 10, windowSeconds: 60 },
+}
+export async function checkRateLimit(ip, endpoint) {
+  const f = globalThis.__HIGHSCORE_FIXTURE__
+  f.rateLimitArgs = { ip, endpoint }
+  return f.allow
+}
+`
+
+const transpile = (srcPath) =>
+  ts.transpileModule(fs.readFileSync(srcPath, 'utf8'), {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+  }).outputText
+
+const toRel = (target) =>
+  './' + path.relative(__dirname, target).split(path.sep).join('/')
+
+const loadModule = async () => {
+  fs.writeFileSync(OCTOKIT_MOCK, OCTOKIT_MOCK_CODE)
+  fs.writeFileSync(NEXT_MOCK, NEXT_MOCK_CODE)
+  fs.writeFileSync(CLIENTIP_MOCK, CLIENTIP_MOCK_CODE)
+  fs.writeFileSync(RATELIMIT_MOCK, RATELIMIT_MOCK_CODE)
+
+  // scoreValidation は実物を通す（外部依存なし）。
+  fs.writeFileSync(SCORE_VALIDATION_BUILD, transpile(SCORE_VALIDATION_SRC))
+
+  const routeCode = transpile(ROUTE_SRC)
+    .replaceAll('next/server', toRel(NEXT_MOCK))
+    .replaceAll('@octokit/rest', toRel(OCTOKIT_MOCK))
+    .replaceAll('./scoreValidation', toRel(SCORE_VALIDATION_BUILD))
+    .replaceAll('../utils/clientIp', toRel(CLIENTIP_MOCK))
+    .replaceAll('../utils/rateLimit', toRel(RATELIMIT_MOCK))
+  fs.writeFileSync(ROUTE_BUILD, routeCode)
+
+  return import(`${ROUTE_BUILD}?t=${process.pid}`)
+}
+
+describe('api/highscore/route.tsx POST（Issue #158: 検証 + レート制限）', () => {
+  let POST
+
+  // score は本来の位置（request body の root）から渡す。allow でレート制限を制御する。
+  const callPost = async (body, fixture) => {
+    globalThis.__HIGHSCORE_FIXTURE__ = {
+      issues: [{ title: 'highscore-game', number: 7, body: '100' }],
+      allow: true,
+      listForRepoCalls: 0,
+      createCalls: 0,
+      updateCalls: 0,
+      throwError: false,
+      ...fixture,
+    }
+    const request =
+      body === '__BAD_JSON__'
+        ? { json: async () => { throw new Error('invalid json') }, headers: new Headers() }
+        : { json: async () => body, headers: new Headers() }
+    const response = await POST(request)
+    return {
+      status: response.status,
+      body: await response.json(),
+      fixture: globalThis.__HIGHSCORE_FIXTURE__,
+    }
+  }
+
+  before(async () => {
+    process.env.GITHUB_TOKEN = 'test-token'
+    process.env.GITHUB_OWNER = 'test-owner'
+    process.env.GITHUB_REPO = 'test-repo'
+    const mod = await loadModule()
+    POST = mod.POST
+  })
+
+  after(() => {
+    delete globalThis.__HIGHSCORE_FIXTURE__
+    for (const f of [
+      ROUTE_BUILD,
+      SCORE_VALIDATION_BUILD,
+      OCTOKIT_MOCK,
+      NEXT_MOCK,
+      CLIENTIP_MOCK,
+      RATELIMIT_MOCK,
+    ]) {
+      if (fs.existsSync(f)) fs.rmSync(f)
+    }
+  })
+
+  it('POST が関数としてエクスポートされている', () => {
+    assert.equal(typeof POST, 'function')
+  })
+
+  it('現在値より高い有効スコアは更新され 200 { updated:true } を返す', async () => {
+    // Given: 現在の最高スコア 100、レート制限は許可
+    // When: 200 を投稿する
+    // Then: 200 で updated:true / highScore:200、Issue が更新される
+    const { status, body, fixture } = await callPost({ score: 200 }, {})
+    assert.equal(status, 200)
+    assert.equal(body.updated, true)
+    assert.equal(body.highScore, 200)
+    assert.equal(fixture.updateCalls, 1)
+  })
+
+  it('現在値以下の有効スコアは更新されず 200 { updated:false } を返す', async () => {
+    // Given: 現在の最高スコア 100
+    // When: 50 を投稿する
+    // Then: 200 で updated:false / highScore:100、Issue は更新されない
+    const { status, body, fixture } = await callPost({ score: 50 }, {})
+    assert.equal(status, 200)
+    assert.equal(body.updated, false)
+    assert.equal(body.highScore, 100)
+    assert.equal(fixture.updateCalls, 0)
+  })
+
+  it('Infinity は 400（typeof の穴を塞ぐ）', async () => {
+    // Given: score=Infinity（typeof は number）
+    // When: 投稿する
+    // Then: 400 で更新されない
+    const { status, fixture } = await callPost({ score: Infinity }, {})
+    assert.equal(status, 400)
+    assert.equal(fixture.updateCalls, 0)
+  })
+
+  it('負値は 400', async () => {
+    // Given: score=-5
+    // Then: 400
+    const { status } = await callPost({ score: -5 }, {})
+    assert.equal(status, 400)
+  })
+
+  it('巨大値は 400', async () => {
+    // Given: 明らかな偽装の巨大値
+    // Then: 400
+    const { status } = await callPost({ score: 1e12 }, {})
+    assert.equal(status, 400)
+  })
+
+  it('数値でない score は 400', async () => {
+    // Given: score が文字列（改ざん）
+    // Then: 400
+    const { status } = await callPost({ score: '200' }, {})
+    assert.equal(status, 400)
+  })
+
+  it('score が欠落していれば 400', async () => {
+    // Given: body に score 無し
+    // Then: 400
+    const { status } = await callPost({}, {})
+    assert.equal(status, 400)
+  })
+
+  it('レート制限に達したら 429（有効スコアでも書込みしない）', async () => {
+    // Given: 有効スコア 200 だがレート制限が拒否
+    // When: 投稿する
+    // Then: 429、Issue は更新されない
+    const { status, fixture } = await callPost({ score: 200 }, { allow: false })
+    assert.equal(status, 429)
+    assert.equal(fixture.updateCalls, 0)
+  })
+
+  it('レート制限は highscore endpoint で判定される', async () => {
+    // Given: 有効スコアの投稿
+    // When: 投稿する
+    // Then: checkRateLimit は endpoint='highscore' で呼ばれる
+    const { fixture } = await callPost({ score: 200 }, {})
+    assert.equal(fixture.rateLimitArgs.endpoint, 'highscore')
+  })
+
+  it('不正な JSON ボディは 400', async () => {
+    // Given: request.json() が throw する不正ボディ
+    // Then: 400（500 でクラッシュさせない）
+    const { status } = await callPost('__BAD_JSON__', {})
+    assert.equal(status, 400)
+  })
+})

--- a/src/app/api/highscore/route.tsx
+++ b/src/app/api/highscore/route.tsx
@@ -1,5 +1,8 @@
 import { Octokit } from '@octokit/rest'
 import { NextRequest, NextResponse } from 'next/server'
+import { getClientIP } from '../utils/clientIp'
+import { checkRateLimit } from '../utils/rateLimit'
+import { isValidScore } from './scoreValidation'
 
 const octokit = new Octokit({
   auth: process.env.GITHUB_TOKEN,
@@ -24,10 +27,32 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const { score } = await request.json()
-  if (typeof score !== 'number') {
-    return NextResponse.json({ error: 'scoreが必要です' }, { status: 400 })
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json(
+      { error: 'リクエストボディが不正です' },
+      { status: 400 },
+    )
   }
+
+  const { score } = (body ?? {}) as { score?: unknown }
+
+  // NaN/Infinity/負値/巨大値/小数/非数値をすべて拒否する（改ざん対策）
+  if (!isValidScore(score)) {
+    return NextResponse.json({ error: 'scoreが不正です' }, { status: 400 })
+  }
+
+  // (IP, endpoint) 単位のレート制限。上限到達時は書込みせず 429 を返す
+  const allowed = await checkRateLimit(getClientIP(request), 'highscore')
+  if (!allowed) {
+    return NextResponse.json(
+      { error: 'リクエストが多すぎます。しばらくしてから再試行してください' },
+      { status: 429 },
+    )
+  }
+
   try {
     const current = await getHighScore()
     if (score > current.highScore) {

--- a/src/app/api/highscore/scoreValidation.test.ts
+++ b/src/app/api/highscore/scoreValidation.test.ts
@@ -1,0 +1,90 @@
+// Issue #158 / TDD 先行: ハイスコア検証の純粋関数 scoreValidation.ts の契約を固定する。
+//
+// 現行 route.tsx の POST は `typeof score !== 'number'` のみで検証しており、
+// typeof NaN === 'number' / typeof Infinity === 'number' のため NaN・Infinity・
+// 負値・巨大値・小数がすべて型チェックを通過して Issue 本文を上書きできてしまう。
+// isValidScore はこの穴を塞ぎ、「0 以上 MAX_HIGH_SCORE 以下の整数」のみを受理する。
+//
+// 実行: `npm test`（node --import tsx --test）。実装前は import で RED、実装後に GREEN。
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { isValidScore, MAX_HIGH_SCORE } from './scoreValidation'
+
+test('MAX_HIGH_SCORE は上限として 100000（正の整数）である', () => {
+  // Given: 計画で定義された安全上限
+  // Then: 正の整数の 100000
+  assert.equal(MAX_HIGH_SCORE, 100_000)
+  assert.equal(Number.isInteger(MAX_HIGH_SCORE), true)
+})
+
+test('isValidScore: 0 は有効', () => {
+  // Given: 下限値 0
+  // When: 検証する
+  // Then: 受理される
+  assert.equal(isValidScore(0), true)
+})
+
+test('isValidScore: 通常の正の整数は有効', () => {
+  // Given: 人間のプレイで到達しうるスコア
+  // Then: 受理される
+  assert.equal(isValidScore(42), true)
+  assert.equal(isValidScore(1), true)
+})
+
+test('isValidScore: 上限 MAX_HIGH_SCORE ちょうどは有効（境界値）', () => {
+  // Given: 上限境界
+  // Then: 受理される
+  assert.equal(isValidScore(MAX_HIGH_SCORE), true)
+})
+
+test('isValidScore: MAX_HIGH_SCORE + 1 は無効（境界値）', () => {
+  // Given: 上限を 1 超えた値
+  // Then: 拒否される（巨大値偽装の拒否）
+  assert.equal(isValidScore(MAX_HIGH_SCORE + 1), false)
+})
+
+test('isValidScore: 負値は無効', () => {
+  // Given: 負のスコア
+  // Then: 拒否される
+  assert.equal(isValidScore(-1), false)
+  assert.equal(isValidScore(-100), false)
+})
+
+test('isValidScore: 小数は無効', () => {
+  // Given: 非整数
+  // Then: 拒否される
+  assert.equal(isValidScore(1.5), false)
+  assert.equal(isValidScore(0.1), false)
+})
+
+test('isValidScore: NaN は無効（typeof の穴を塞ぐ）', () => {
+  // Given: NaN（typeof NaN === 'number'）
+  // Then: 拒否される
+  assert.equal(isValidScore(NaN), false)
+})
+
+test('isValidScore: Infinity / -Infinity は無効（typeof の穴を塞ぐ）', () => {
+  // Given: 無限大（typeof Infinity === 'number'）
+  // Then: 拒否される
+  assert.equal(isValidScore(Infinity), false)
+  assert.equal(isValidScore(-Infinity), false)
+})
+
+test('isValidScore: 巨大値（Number.MAX_VALUE）は無効', () => {
+  // Given: 明らかな偽装の巨大値
+  // Then: 拒否される
+  assert.equal(isValidScore(Number.MAX_VALUE), false)
+  assert.equal(isValidScore(1e12), false)
+})
+
+test('isValidScore: number 以外の型は無効', () => {
+  // Given: 数値でない入力（外部 JSON からの改ざん）
+  // Then: すべて拒否される
+  assert.equal(isValidScore('42'), false)
+  assert.equal(isValidScore(null), false)
+  assert.equal(isValidScore(undefined), false)
+  assert.equal(isValidScore(true), false)
+  assert.equal(isValidScore({}), false)
+  assert.equal(isValidScore([]), false)
+})

--- a/src/app/api/highscore/scoreValidation.ts
+++ b/src/app/api/highscore/scoreValidation.ts
@@ -1,0 +1,16 @@
+// Issue #158: ハイスコアの改ざん対策。
+// 現行の `typeof score !== 'number'` は typeof NaN / typeof Infinity が 'number' のため
+// NaN・Infinity・負値・巨大値・小数を通してしまう。isValidScore はこの穴を塞ぐ。
+
+// 人間のプレイで到達しうる範囲を超える値を偽装として拒否する安全上限。
+export const MAX_HIGH_SCORE = 100_000
+
+// 「0 以上 MAX_HIGH_SCORE 以下の整数」のみを受理する型ガード。
+export function isValidScore(score: unknown): score is number {
+  return (
+    typeof score === 'number' &&
+    Number.isInteger(score) &&
+    score >= 0 &&
+    score <= MAX_HIGH_SCORE
+  )
+}

--- a/src/app/api/likes/route.test.mjs
+++ b/src/app/api/likes/route.test.mjs
@@ -1,0 +1,253 @@
+// Issue #158 / TDD 先行: likes POST の配線（入力検証 → レート制限 → 更新）を検証する結合テスト。
+//
+// 対象データフロー（計画 §4.3）: request.json → articleId/liked 検証 → checkRateLimit → updateLike。
+// 現行 POST は articleId 存在チェックのみで無制限に書込み可能。本テストは
+// liked の boolean 検証と、新ステータス 429 が既存 200/400/500 フローへ合流する配線を固定する。
+//
+// route は ./githubLikes 経由で octokit に依存する。既存 likes/bulk/route.test.mjs に倣い
+// transpile + import 張り替え方式（node:test + typescript のみ、新規パッケージ無し）を用い、
+// githubLikes・checkRateLimit・getClientIP・next/server を境界でモックする。
+//
+// 実行: `node --test src/app/api/likes/route.test.mjs`
+// 実装前は route が未配線のため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { after, before, describe, it } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROUTE_SRC = path.join(__dirname, 'route.tsx')
+
+const ROUTE_BUILD = path.join(__dirname, '.route.test-build.mjs')
+const GITHUB_LIKES_MOCK = path.join(__dirname, '.githubLikes.test-mock.mjs')
+const NEXT_MOCK = path.join(__dirname, '.next-server.test-mock.mjs')
+const CLIENTIP_MOCK = path.join(__dirname, '.clientIp.test-mock.mjs')
+const RATELIMIT_MOCK = path.join(__dirname, '.rateLimit.test-mock.mjs')
+
+// githubLikes をまるごとモックする。route が使う octokit / parseLikeCount /
+// likeIssueTitle / LIKES_ISSUE_LABEL を提供し、issues データと更新呼び出しを fixture に記録する。
+const GITHUB_LIKES_MOCK_CODE = `
+export const LIKES_ISSUE_LABEL = 'blog-likes'
+export const likeIssueTitle = (articleId) => 'likes-' + articleId
+export const parseLikeCount = (body) => {
+  const n = parseInt(String(body).trim(), 10)
+  return isNaN(n) ? 0 : n
+}
+const fx = () => globalThis.__LIKES_FIXTURE__
+export const octokit = {
+  issues: {
+    listForRepo: async () => {
+      const f = fx()
+      if (f.throwError) throw new Error('github boom')
+      return { data: f.issues }
+    },
+    create: async () => {
+      const f = fx()
+      f.createCalls = (f.createCalls || 0) + 1
+      return { data: { number: 999 } }
+    },
+    get: async () => ({ data: {} }),
+    update: async (args) => {
+      const f = fx()
+      f.updateCalls = (f.updateCalls || 0) + 1
+      f.updateArgs = args
+      return { data: {} }
+    },
+  },
+  search: {
+    issuesAndPullRequests: async () => ({ data: { items: [] } }),
+  },
+}
+`
+
+const NEXT_MOCK_CODE = `
+export class NextRequest {}
+export const NextResponse = {
+  json(body, init) {
+    return {
+      status: (init && init.status) || 200,
+      async json() { return body },
+    }
+  },
+}
+`
+
+const CLIENTIP_MOCK_CODE = `
+export function getClientIP() { return '203.0.113.5' }
+`
+
+const RATELIMIT_MOCK_CODE = `
+export const RATE_LIMITS = {
+  likes: { max: 30, windowSeconds: 60 },
+  highscore: { max: 10, windowSeconds: 60 },
+}
+export async function checkRateLimit(ip, endpoint) {
+  const f = globalThis.__LIKES_FIXTURE__
+  f.rateLimitArgs = { ip, endpoint }
+  return f.allow
+}
+`
+
+const transpile = (srcPath) =>
+  ts.transpileModule(fs.readFileSync(srcPath, 'utf8'), {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+  }).outputText
+
+const toRel = (target) =>
+  './' + path.relative(__dirname, target).split(path.sep).join('/')
+
+const loadModule = async () => {
+  fs.writeFileSync(GITHUB_LIKES_MOCK, GITHUB_LIKES_MOCK_CODE)
+  fs.writeFileSync(NEXT_MOCK, NEXT_MOCK_CODE)
+  fs.writeFileSync(CLIENTIP_MOCK, CLIENTIP_MOCK_CODE)
+  fs.writeFileSync(RATELIMIT_MOCK, RATELIMIT_MOCK_CODE)
+
+  const routeCode = transpile(ROUTE_SRC)
+    .replaceAll('next/server', toRel(NEXT_MOCK))
+    .replaceAll('./githubLikes', toRel(GITHUB_LIKES_MOCK))
+    .replaceAll('../utils/clientIp', toRel(CLIENTIP_MOCK))
+    .replaceAll('../utils/rateLimit', toRel(RATELIMIT_MOCK))
+  fs.writeFileSync(ROUTE_BUILD, routeCode)
+
+  return import(`${ROUTE_BUILD}?t=${process.pid}`)
+}
+
+describe('api/likes/route.tsx POST（Issue #158: 入力検証 + レート制限）', () => {
+  let POST
+
+  // articleId / liked は本来の位置（request body の root）から渡す。allow でレート制限を制御する。
+  const callPost = async (body, fixture) => {
+    globalThis.__LIKES_FIXTURE__ = {
+      issues: [{ title: 'likes-hello-world', number: 3, body: '5' }],
+      allow: true,
+      createCalls: 0,
+      updateCalls: 0,
+      throwError: false,
+      ...fixture,
+    }
+    const request =
+      body === '__BAD_JSON__'
+        ? { json: async () => { throw new Error('invalid json') }, headers: new Headers() }
+        : { json: async () => body, headers: new Headers() }
+    const response = await POST(request)
+    return {
+      status: response.status,
+      body: await response.json(),
+      fixture: globalThis.__LIKES_FIXTURE__,
+    }
+  }
+
+  before(async () => {
+    process.env.GITHUB_TOKEN = 'test-token'
+    process.env.GITHUB_OWNER = 'test-owner'
+    process.env.GITHUB_REPO = 'test-repo'
+    const mod = await loadModule()
+    POST = mod.POST
+  })
+
+  after(() => {
+    delete globalThis.__LIKES_FIXTURE__
+    for (const f of [
+      ROUTE_BUILD,
+      GITHUB_LIKES_MOCK,
+      NEXT_MOCK,
+      CLIENTIP_MOCK,
+      RATELIMIT_MOCK,
+    ]) {
+      if (fs.existsSync(f)) fs.rmSync(f)
+    }
+  })
+
+  it('POST が関数としてエクスポートされている', () => {
+    assert.equal(typeof POST, 'function')
+  })
+
+  it('liked=true・許可時はいいねを +1 して 200 を返す', async () => {
+    // Given: 現在 5 いいね、レート制限は許可
+    // When: liked=true を投稿する
+    // Then: 200 で likeCount:6、Issue が更新される
+    const { status, body, fixture } = await callPost(
+      { articleId: 'hello-world', liked: true },
+      {},
+    )
+    assert.equal(status, 200)
+    assert.equal(body.likeCount, 6)
+    assert.equal(body.liked, true)
+    assert.equal(fixture.updateCalls, 1)
+  })
+
+  it('liked=false・許可時はいいねを -1 して 200 を返す', async () => {
+    // Given: 現在 5 いいね
+    // When: liked=false を投稿する
+    // Then: 200 で likeCount:4
+    const { status, body } = await callPost(
+      { articleId: 'hello-world', liked: false },
+      {},
+    )
+    assert.equal(status, 200)
+    assert.equal(body.likeCount, 4)
+  })
+
+  it('articleId が欠落していれば 400（更新しない）', async () => {
+    // Given: articleId 無し
+    // Then: 400、Issue は更新されない
+    const { status, fixture } = await callPost({ liked: true }, {})
+    assert.equal(status, 400)
+    assert.equal(fixture.updateCalls, 0)
+  })
+
+  it('liked が boolean でなければ 400（改ざん入力の拒否）', async () => {
+    // Given: liked が文字列
+    // When: 投稿する
+    // Then: 400、Issue は更新されない
+    const { status, fixture } = await callPost(
+      { articleId: 'hello-world', liked: 'true' },
+      {},
+    )
+    assert.equal(status, 400)
+    assert.equal(fixture.updateCalls, 0)
+  })
+
+  it('liked が欠落していれば 400', async () => {
+    // Given: liked 無し
+    // Then: 400
+    const { status } = await callPost({ articleId: 'hello-world' }, {})
+    assert.equal(status, 400)
+  })
+
+  it('レート制限に達したら 429（有効入力でも書込みしない）', async () => {
+    // Given: 有効入力だがレート制限が拒否
+    // When: 投稿する
+    // Then: 429、Issue は更新されない
+    const { status, fixture } = await callPost(
+      { articleId: 'hello-world', liked: true },
+      { allow: false },
+    )
+    assert.equal(status, 429)
+    assert.equal(fixture.updateCalls, 0)
+  })
+
+  it('レート制限は likes endpoint で判定される', async () => {
+    // Given: 有効入力の投稿
+    // When: 投稿する
+    // Then: checkRateLimit は endpoint='likes' で呼ばれる
+    const { fixture } = await callPost(
+      { articleId: 'hello-world', liked: true },
+      {},
+    )
+    assert.equal(fixture.rateLimitArgs.endpoint, 'likes')
+  })
+
+  it('不正な JSON ボディは 400', async () => {
+    // Given: request.json() が throw する不正ボディ
+    // Then: 400（500 でクラッシュさせない）
+    const { status } = await callPost('__BAD_JSON__', {})
+    assert.equal(status, 400)
+  })
+})

--- a/src/app/api/likes/route.tsx
+++ b/src/app/api/likes/route.tsx
@@ -1,5 +1,7 @@
 // app/api/likes/route.ts
 import { NextRequest, NextResponse } from 'next/server'
+import { getClientIP } from '../utils/clientIp'
+import { checkRateLimit } from '../utils/rateLimit'
 import {
   LIKES_ISSUE_LABEL,
   likeIssueTitle,
@@ -32,10 +34,40 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const { articleId, liked } = await request.json()
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json(
+      { error: 'リクエストボディが不正です' },
+      { status: 400 },
+    )
+  }
 
-  if (!articleId) {
+  const { articleId, liked } = (body ?? {}) as {
+    articleId?: unknown
+    liked?: unknown
+  }
+
+  if (typeof articleId !== 'string' || articleId.length === 0) {
     return NextResponse.json({ error: '記事IDが必要です' }, { status: 400 })
+  }
+
+  // 改ざん入力を拒否する（liked は boolean のみ受理）
+  if (typeof liked !== 'boolean') {
+    return NextResponse.json(
+      { error: 'likedパラメータが必要です' },
+      { status: 400 },
+    )
+  }
+
+  // (IP, endpoint) 単位のレート制限。上限到達時は書込みせず 429 を返す
+  const allowed = await checkRateLimit(getClientIP(request), 'likes')
+  if (!allowed) {
+    return NextResponse.json(
+      { error: 'リクエストが多すぎます。しばらくしてから再試行してください' },
+      { status: 429 },
+    )
   }
 
   try {

--- a/src/app/api/tanka-likes/route.tsx
+++ b/src/app/api/tanka-likes/route.tsx
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js'
 import { NextRequest, NextResponse } from 'next/server'
+import { getClientIP } from '../utils/clientIp'
 
 // tweet_idを正規化する関数（文字列として扱う）
 function normalizeTweetId(raw: any): string | null {
@@ -7,24 +8,6 @@ function normalizeTweetId(raw: any): string | null {
   const s = String(raw).trim()
   if (!/^\d+$/.test(s)) return null
   return s
-}
-
-// クライアントIPアドレスを取得する関数
-function getClientIP(request: NextRequest): string {
-  // Vercelの場合
-  const forwarded = request.headers.get('x-forwarded-for')
-  if (forwarded) {
-    return forwarded.split(',')[0].trim()
-  }
-
-  // その他のプロキシ
-  const realIP = request.headers.get('x-real-ip')
-  if (realIP) {
-    return realIP
-  }
-
-  // フォールバック
-  return '127.0.0.1'
 }
 
 export async function GET(request: NextRequest) {

--- a/src/app/api/utils/clientIp.test.ts
+++ b/src/app/api/utils/clientIp.test.ts
@@ -1,0 +1,86 @@
+// Issue #158 / TDD 先行: 共有 util clientIp.ts の getClientIP 契約を固定する。
+//
+// getClientIP は現在 tanka-likes/route.tsx にローカル定義されている実装
+// （x-forwarded-for 先頭 → x-real-ip → 127.0.0.1 フォールバック）を共有 util へ
+// 集約したもの。レート制限の IP キーとして likes/highscore/tanka-likes から共用する。
+//
+// 実行: `npm test`（node --import tsx --test）。実装前は import で RED、実装後に GREEN。
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { getClientIP } from './clientIp'
+
+// getClientIP は request.headers.get(name) のみ使用する。
+// Web 標準 Headers を持つ最小オブジェクトで NextRequest を代替する。
+const makeRequest = (headers: Record<string, string>) =>
+  ({ headers: new Headers(headers) }) as unknown as Parameters<
+    typeof getClientIP
+  >[0]
+
+test('x-forwarded-for が単一 IP のときはその IP を返す', () => {
+  // Given: x-forwarded-for に 1 つの IP
+  // When: 解決する
+  // Then: その IP
+  assert.equal(
+    getClientIP(makeRequest({ 'x-forwarded-for': '203.0.113.5' })),
+    '203.0.113.5',
+  )
+})
+
+test('x-forwarded-for がカンマ区切りのときは先頭（クライアント）IP を返す', () => {
+  // Given: プロキシ経由で複数 IP が連結
+  // When: 解決する
+  // Then: 先頭のクライアント IP のみ
+  assert.equal(
+    getClientIP(
+      makeRequest({
+        'x-forwarded-for': '203.0.113.5, 70.41.3.18, 150.172.238.178',
+      }),
+    ),
+    '203.0.113.5',
+  )
+})
+
+test('x-forwarded-for 先頭 IP の前後空白はトリムされる', () => {
+  // Given: 空白付きの値
+  // When: 解決する
+  // Then: トリムされた IP
+  assert.equal(
+    getClientIP(
+      makeRequest({ 'x-forwarded-for': '  203.0.113.5 , 70.41.3.18' }),
+    ),
+    '203.0.113.5',
+  )
+})
+
+test('x-forwarded-for が無く x-real-ip があるときは x-real-ip を返す', () => {
+  // Given: x-forwarded-for 無し、x-real-ip あり
+  // When: 解決する
+  // Then: x-real-ip の値
+  assert.equal(
+    getClientIP(makeRequest({ 'x-real-ip': '198.51.100.9' })),
+    '198.51.100.9',
+  )
+})
+
+test('x-forwarded-for が x-real-ip より優先される', () => {
+  // Given: 両ヘッダが存在
+  // When: 解決する
+  // Then: x-forwarded-for が優先
+  assert.equal(
+    getClientIP(
+      makeRequest({
+        'x-forwarded-for': '203.0.113.5',
+        'x-real-ip': '198.51.100.9',
+      }),
+    ),
+    '203.0.113.5',
+  )
+})
+
+test('どちらのヘッダも無いときは 127.0.0.1 にフォールバックする', () => {
+  // Given: IP 系ヘッダ無し
+  // When: 解決する
+  // Then: ローカルホストへフォールバック
+  assert.equal(getClientIP(makeRequest({})), '127.0.0.1')
+})

--- a/src/app/api/utils/clientIp.ts
+++ b/src/app/api/utils/clientIp.ts
@@ -1,0 +1,17 @@
+import type { NextRequest } from 'next/server'
+
+// クライアント IP を解決する。レート制限のキーとして likes/highscore/tanka-likes から共用する。
+// x-forwarded-for 先頭（クライアント）→ x-real-ip → ローカルホストの順で解決する。
+export function getClientIP(request: NextRequest): string {
+  const forwarded = request.headers.get('x-forwarded-for')
+  if (forwarded) {
+    return forwarded.split(',')[0].trim()
+  }
+
+  const realIP = request.headers.get('x-real-ip')
+  if (realIP) {
+    return realIP
+  }
+
+  return '127.0.0.1'
+}

--- a/src/app/api/utils/rateLimit.test.mjs
+++ b/src/app/api/utils/rateLimit.test.mjs
@@ -1,0 +1,231 @@
+// Issue #158 / TDD 先行: 共有レート制限モジュール rateLimit.ts の契約を検証する単体テスト。
+//
+// rateLimit.ts は Supabase の plpgsql 関数 check_api_rate_limit を RPC 経由で呼び、
+// (ip, endpoint) 単位のウィンドウ内書込み回数を判定する。設計方針（計画 §4.1）:
+//   - checkRateLimit(ip, endpoint): 許可=true / 拒否=false
+//   - RATE_LIMITS に endpoint ごとの { max, windowSeconds } を集約
+//   - RPC には check_api_rate_limit(ip_param, endpoint_param, max_requests, window_seconds) を渡す
+//   - フェイルオープン: Supabase 未設定 / RPC エラー時は true を返す（コア機能を落とさない）
+//
+// 既存 tanka/route.test.mjs・likes/bulk/route.test.mjs と同じく、Node 組み込み node:test と
+// devDependency の typescript のみで構成する。rateLimit.ts を JS へトランスパイルし、
+// @supabase/supabase-js の import 指定子をハーミティックなモックへ張り替えて動的 import する。
+//
+// 実行: `node --test src/app/api/utils/rateLimit.test.mjs`
+// 実装前は rateLimit.ts が未作成のため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { after, before, beforeEach, describe, it } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const RATE_LIMIT_SRC = path.join(__dirname, 'rateLimit.ts')
+
+const RATE_LIMIT_BUILD = path.join(__dirname, '.rateLimit.test-build.mjs')
+const SUPABASE_MOCK = path.join(__dirname, '.supabase.test-mock.mjs')
+
+// @supabase/supabase-js のモック。createClient(...).rpc(fn, params) の呼び出しを
+// グローバル fixture に記録し、返す { data, error } を fixture から制御する。
+const SUPABASE_MOCK_CODE = `
+export function createClient(url, key) {
+  const fx = () => globalThis.__RATE_LIMIT_FIXTURE__
+  const f = fx()
+  f.createClientCalls = (f.createClientCalls || 0) + 1
+  f.createClientArgs = { url, key }
+  return {
+    rpc: async (fn, params) => {
+      f.rpcCalls = (f.rpcCalls || 0) + 1
+      f.rpcArgs = { fn, params }
+      if (f.throwError) throw new Error('supabase boom')
+      return { data: f.rpcData, error: f.rpcError }
+    },
+  }
+}
+`
+
+const transpile = (srcPath) =>
+  ts.transpileModule(fs.readFileSync(srcPath, 'utf8'), {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+  }).outputText
+
+const toRel = (target) =>
+  './' + path.relative(__dirname, target).split(path.sep).join('/')
+
+const loadModule = async () => {
+  fs.writeFileSync(SUPABASE_MOCK, SUPABASE_MOCK_CODE)
+  const code = transpile(RATE_LIMIT_SRC).replaceAll(
+    '@supabase/supabase-js',
+    toRel(SUPABASE_MOCK),
+  )
+  fs.writeFileSync(RATE_LIMIT_BUILD, code)
+  return import(`${RATE_LIMIT_BUILD}?t=${process.pid}`)
+}
+
+describe('api/utils/rateLimit.ts checkRateLimit（Issue #158: レート制限契約）', () => {
+  let checkRateLimit
+  let RATE_LIMITS
+  let warnCalls
+
+  const originalWarn = console.warn
+
+  const setFixture = (fixture) => {
+    globalThis.__RATE_LIMIT_FIXTURE__ = {
+      rpcData: null,
+      rpcError: null,
+      throwError: false,
+      createClientCalls: 0,
+      rpcCalls: 0,
+      ...fixture,
+    }
+  }
+
+  before(async () => {
+    process.env.SUPABASE_URL = 'https://example.supabase.co'
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key'
+    const mod = await loadModule()
+    checkRateLimit = mod.checkRateLimit
+    RATE_LIMITS = mod.RATE_LIMITS
+  })
+
+  beforeEach(() => {
+    warnCalls = 0
+    console.warn = () => {
+      warnCalls += 1
+    }
+  })
+
+  after(() => {
+    console.warn = originalWarn
+    delete globalThis.__RATE_LIMIT_FIXTURE__
+    for (const f of [RATE_LIMIT_BUILD, SUPABASE_MOCK]) {
+      if (fs.existsSync(f)) fs.rmSync(f)
+    }
+  })
+
+  it('checkRateLimit / RATE_LIMITS がエクスポートされている', () => {
+    assert.equal(typeof checkRateLimit, 'function')
+    assert.equal(typeof RATE_LIMITS, 'object')
+  })
+
+  it('RATE_LIMITS に likes / highscore の { max, windowSeconds } が定義されている', () => {
+    // Given: endpoint ごとの方針を 1 箇所に集約する設計
+    // Then: likes / highscore の閾値が正の整数で存在する
+    for (const key of ['likes', 'highscore']) {
+      assert.ok(RATE_LIMITS[key], `${key} が定義されているべき`)
+      assert.equal(Number.isInteger(RATE_LIMITS[key].max), true)
+      assert.ok(RATE_LIMITS[key].max > 0)
+      assert.equal(Number.isInteger(RATE_LIMITS[key].windowSeconds), true)
+      assert.ok(RATE_LIMITS[key].windowSeconds > 0)
+    }
+  })
+
+  it('RPC が data:true を返したら許可（true）', async () => {
+    // Given: ウィンドウ内で上限未満
+    // When: checkRateLimit を呼ぶ
+    // Then: true（許可）
+    setFixture({ rpcData: true })
+    assert.equal(await checkRateLimit('203.0.113.5', 'likes'), true)
+  })
+
+  it('RPC が data:false を返したら拒否（false）', async () => {
+    // Given: ウィンドウ内で上限到達
+    // When: checkRateLimit を呼ぶ
+    // Then: false（拒否）
+    setFixture({ rpcData: false })
+    assert.equal(await checkRateLimit('203.0.113.5', 'highscore'), false)
+  })
+
+  it('RPC には check_api_rate_limit と endpoint に対応する閾値が渡される', async () => {
+    // Given: highscore の呼び出し
+    // When: checkRateLimit を呼ぶ
+    // Then: 関数名・IP・endpoint・RATE_LIMITS の閾値が RPC に渡る
+    setFixture({ rpcData: true })
+    await checkRateLimit('198.51.100.9', 'highscore')
+    const { fn, params } = globalThis.__RATE_LIMIT_FIXTURE__.rpcArgs
+    assert.equal(fn, 'check_api_rate_limit')
+    assert.equal(params.ip_param, '198.51.100.9')
+    assert.equal(params.endpoint_param, 'highscore')
+    assert.equal(params.max_requests, RATE_LIMITS.highscore.max)
+    assert.equal(params.window_seconds, RATE_LIMITS.highscore.windowSeconds)
+  })
+
+  it('RPC がエラーを返したらフェイルオープン（true）＋ warn で可視化', async () => {
+    // Given: RPC が error を返す（Supabase 障害）
+    // When: checkRateLimit を呼ぶ
+    // Then: コア機能を落とさないため true。ただし握りつぶさず warn する
+    setFixture({ rpcError: { message: 'rpc failed' } })
+    assert.equal(await checkRateLimit('203.0.113.5', 'likes'), true)
+    assert.ok(warnCalls >= 1, 'エラーは console.warn で可視化されるべき')
+  })
+
+  it('RPC が例外を投げてもフェイルオープン（true）＋ warn', async () => {
+    // Given: RPC 呼び出しが throw
+    // When: checkRateLimit を呼ぶ
+    // Then: true（フェイルオープン）＋ warn
+    setFixture({ throwError: true })
+    assert.equal(await checkRateLimit('203.0.113.5', 'likes'), true)
+    assert.ok(warnCalls >= 1)
+  })
+})
+
+describe('api/utils/rateLimit.ts checkRateLimit（Supabase 未設定時）', () => {
+  let checkRateLimit
+  let warnCalls
+  const originalWarn = console.warn
+  const savedUrl = process.env.SUPABASE_URL
+  const savedKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  before(async () => {
+    // 環境変数を外した状態でモジュールを再ロードする
+    delete process.env.SUPABASE_URL
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY
+    globalThis.__RATE_LIMIT_FIXTURE__ = {
+      rpcData: null,
+      rpcError: null,
+      throwError: false,
+      createClientCalls: 0,
+      rpcCalls: 0,
+    }
+    fs.writeFileSync(SUPABASE_MOCK, SUPABASE_MOCK_CODE)
+    const code = transpile(RATE_LIMIT_SRC).replaceAll(
+      '@supabase/supabase-js',
+      toRel(SUPABASE_MOCK),
+    )
+    fs.writeFileSync(RATE_LIMIT_BUILD, code)
+    const mod = await import(`${RATE_LIMIT_BUILD}?t=${process.pid}-noenv`)
+    checkRateLimit = mod.checkRateLimit
+  })
+
+  beforeEach(() => {
+    warnCalls = 0
+    console.warn = () => {
+      warnCalls += 1
+    }
+  })
+
+  after(() => {
+    console.warn = originalWarn
+    if (savedUrl !== undefined) process.env.SUPABASE_URL = savedUrl
+    if (savedKey !== undefined) process.env.SUPABASE_SERVICE_ROLE_KEY = savedKey
+    delete globalThis.__RATE_LIMIT_FIXTURE__
+    for (const f of [RATE_LIMIT_BUILD, SUPABASE_MOCK]) {
+      if (fs.existsSync(f)) fs.rmSync(f)
+    }
+  })
+
+  it('Supabase 未設定ならフェイルオープン（true）で RPC を呼ばない', async () => {
+    // Given: SUPABASE_URL / SERVICE_ROLE_KEY が未設定
+    // When: checkRateLimit を呼ぶ
+    // Then: true（フェイルオープン）。createClient / rpc は呼ばれない
+    assert.equal(await checkRateLimit('203.0.113.5', 'likes'), true)
+    assert.equal(globalThis.__RATE_LIMIT_FIXTURE__.rpcCalls, 0)
+    assert.equal(globalThis.__RATE_LIMIT_FIXTURE__.createClientCalls, 0)
+    assert.ok(warnCalls >= 1, '設定欠如は console.warn で可視化されるべき')
+  })
+})

--- a/src/app/api/utils/rateLimit.ts
+++ b/src/app/api/utils/rateLimit.ts
@@ -1,0 +1,67 @@
+import { createClient } from '@supabase/supabase-js'
+
+// Issue #158: (IP, endpoint) 単位の書込みレート制限。
+// Supabase の plpgsql 関数 check_api_rate_limit を RPC 経由で呼び、
+// ウィンドウ内の書込み回数が上限未満かを判定する（scripts/migrations/007_api_rate_limits.sql）。
+
+// RPC 関数名。契約文字列は 1 箇所で定義する。
+const RATE_LIMIT_RPC = 'check_api_rate_limit'
+
+export interface RateLimitRule {
+  max: number
+  windowSeconds: number
+}
+
+// endpoint ごとの閾値を 1 箇所へ集約する。
+export const RATE_LIMITS = {
+  likes: { max: 30, windowSeconds: 60 },
+  highscore: { max: 10, windowSeconds: 60 },
+} satisfies Record<string, RateLimitRule>
+
+export type RateLimitEndpoint = keyof typeof RATE_LIMITS
+
+// ウィンドウ内で上限未満なら true（許可）、上限到達なら false（拒否）。
+// Supabase 未設定 / RPC エラー / 例外時はコア機能を落とさないためフェイルオープン（true）。
+// ただしエラーは握りつぶさず console.warn で可視化する。
+export async function checkRateLimit(
+  ip: string,
+  endpoint: RateLimitEndpoint,
+): Promise<boolean> {
+  const url = process.env.SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!url || !key) {
+    console.warn(
+      'レート制限をスキップします: Supabase の環境変数が未設定です（フェイルオープン）',
+    )
+    return true
+  }
+
+  const rule = RATE_LIMITS[endpoint]
+
+  try {
+    const supabase = createClient(url, key)
+    const { data, error } = await supabase.rpc(RATE_LIMIT_RPC, {
+      ip_param: ip,
+      endpoint_param: endpoint,
+      max_requests: rule.max,
+      window_seconds: rule.windowSeconds,
+    })
+
+    if (error) {
+      console.warn(
+        'レート制限チェックに失敗しました（フェイルオープン）:',
+        error,
+      )
+      return true
+    }
+
+    return data === true
+  } catch (error) {
+    console.warn(
+      'レート制限チェックで例外が発生しました（フェイルオープン）:',
+      error,
+    )
+    return true
+  }
+}


### PR DESCRIPTION
## 概要
GitHub Issue #158「いいね/ハイスコアAPIにレート制限・改ざん対策がなく無制限に書込み可能」を takt（default workflow: テスト先行）で実装。

## 概要
`/likes` と `/highscore` の POST は誰でも無制限に呼べ、GitHub Issue 本文を直接更新する。スクリプトで連打すればいいね水増し・スコア偽装が容易で、GitHub API レート消費にも繋がる。

## 根拠
- `src/app/api/likes/route.tsx:34-52`
- `src/app/api/highscore/route.tsx:26-46`

## 改善案
- [ ] IP / セッション単位のレート制限を追加（`tanka-likes` のように `user_ip` 記録で一意化）
- [ ] ハイスコアは上限値・型範囲チェックを強化（負値 / 巨大値の拒否）
- [ ] 可能なら署名トークンや CAPTCHA 等で自動投稿を抑制

工数: M

---
Workflow `default` completed successfully.

Closes #158

🤖 Generated with takt + Claude Code