### PR TITLE
fix(toc): tocbot の import を namespace 形式に変更（TS 5.9 互換）

### DIFF
--- a/src/app/components/molecules/Toc.tsx
+++ b/src/app/components/molecules/Toc.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect } from 'react'
 import { useInView } from 'react-intersection-observer'
-import tocbot from 'tocbot'
+import * as tocbot from 'tocbot'
 
 const Toc: React.FC = () => {
   const { ref, inView } = useInView({


### PR DESCRIPTION
## 背景
dependabot の dev-deps グループ更新（#203）で TypeScript が 5.5.4→5.9.3 に上がると、tocbot（`"type": "module"` だが型定義は `export = tocbot`）の default import が `Module '"tocbot"' has no default export` になり Vercel ビルドが失敗する。

## 変更
- `src/app/components/molecules/Toc.tsx` の import を `import * as tocbot from 'tocbot'` に変更（1行のみ）
- TypeScript **5.9.3 と 5.5.4 の両方**で `npm run build` 緑を確認済み（#203 マージ前後どちらでも壊れない）

#203 のブロッカー解消用。本PRマージ後に #203 を rebase すれば緑になる見込み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)