### PR TITLE
[#224] UI刷新(2/3): トップページ刷新（お知らせ欄・ヒーロー・ヘッダーstagger）

### DIFF
--- a/src/app/components/atoms/TitleAnimation.test.tsx
+++ b/src/app/components/atoms/TitleAnimation.test.tsx
@@ -1,0 +1,103 @@
+// ヒーロー演出（src/app/components/atoms/TitleAnimation.tsx）の刷新後の
+// 表示契約を固定する単体テスト（Issue #224 UI刷新 2/3 / TDD 先行）。
+//
+// #224 は GSAP TextPlugin による 1 文字ずつのタイプライター描画をやめ、
+// フェードイン（opacity + わずかな blur + 軽い上移動）へ差し替える。これに伴い
+// タイトル文字「Furugen」「Island」は JSX で直接描画され、初期マークアップから
+// 可視になる（＝ JS/アニメーションに依存せず即時表示できる）。これは
+// prefers-reduced-motion: reduce 時に「即時表示」を満たす前提でもある。
+// また縦書き "scroll" の下のテキスト「↓」は細い線のアイコン（faArrowDown）へ
+// 置き換える。本テストはこれらの静的マークアップ契約を固定する。
+//
+// reduced-motion の実挙動（matchMedia による分岐）は useEffect 依存のランタイム
+// 挙動で、renderToStaticMarkup は effect を実行しないため本テストの対象外。ここでは
+// 「初期マークアップにタイトル文字が存在する」ことで、reduce/no-JS でも文字が
+// 見える回帰不変条件を固定する（旧実装は空 div へ後から text を注入していた）。
+//
+// 既存の style テスト群と同じく node 組み込み node:test と
+// react-dom/server の renderToStaticMarkup のみで構成する。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は TextPlugin による空 div＋テキスト「↓」のため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+// CSS Module（もし import されても）を無害化する resolve フック。
+const resolveHook = `
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.endsWith('.css')) {
+    return { url: 'data:text/javascript,export default {}', shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}
+`
+register(
+  'data:text/javascript,' + encodeURIComponent(resolveHook),
+  import.meta.url,
+)
+
+// tsx は classic JSX runtime へ変換するため React をグローバルに渡す。
+;(globalThis as Record<string, unknown>).React = React
+
+let TitleAnimation: React.FC
+before(async () => {
+  TitleAnimation = (await import('./TitleAnimation'))
+    .default as unknown as React.FC
+})
+
+const render = (): string => renderToStaticMarkup(<TitleAnimation />)
+
+test('TitleAnimation: 例外なく描画される', () => {
+  // Given/When/Then: フェードイン化後も SSR 描画で throw しない
+  assert.doesNotThrow(() => render())
+})
+
+test('TitleAnimation: タイトル文字を初期マークアップに描画する（Furugen）', () => {
+  // Given/When: ヒーローを描画する
+  const html = render()
+  // Then: JSX 直接描画により「Furugen」が初期マークアップに含まれる
+  //（旧実装は空 div へ後から注入するため初期マークアップには存在しなかった）
+  assert.ok(html.includes('Furugen'), 'Furugen を含む')
+})
+
+test('TitleAnimation: タイトル文字を初期マークアップに描画する（Island）', () => {
+  // Given/When: ヒーローを描画する
+  const html = render()
+  // Then: 2 行目「Island」も初期マークアップに含まれる
+  assert.ok(html.includes('Island'), 'Island を含む')
+})
+
+test('TitleAnimation: 縦書き "scroll" ラベルは維持する', () => {
+  // Given/When: ヒーローを描画する
+  const html = render()
+  // Then: 世界観を変えないため scroll ラベルは残す
+  assert.ok(html.includes('scroll'), 'scroll を含む')
+})
+
+test('TitleAnimation: テキストの「↓」をやめアイコン（SVG）へ置き換える', () => {
+  // Given/When: ヒーローを描画する
+  const html = render()
+  // Then: 生の矢印文字は使わず、細い線のアイコンへ置き換える
+  assert.ok(!html.includes('↓'), 'テキストの ↓ を含まない')
+})
+
+test('TitleAnimation: 下向き矢印を faArrowDown アイコンで描画する', () => {
+  // Given/When: ヒーローを描画する
+  const html = render()
+  // Then: FontAwesome の下矢印アイコン（arrow-down）が SVG として描画される
+  assert.match(html, /data-icon="arrow-down"/, 'arrow-down アイコンを含む')
+})
+
+test('TitleAnimation: 初期マークアップにフェード開始状態（opacity:0）を焼き込まない', () => {
+  // FOUC 対策（フェード開始状態を pre-paint で確定）は useLayoutEffect 側で行い、
+  // JSX/インライン style に opacity:0 を焼き込まないことが不変条件。焼き込むと
+  // no-JS / reduced-motion 時にタイトルが不可視になり回帰する。
+  // Given/When: ヒーローを SSR 描画する（effect は実行されない）
+  const html = render()
+  // Then: 初期マークアップの style に opacity:0 が現れない（＝即時可視を保つ）
+  assert.ok(!/opacity:\s*0/.test(html), '初期 style に opacity:0 を含まない')
+})

--- a/src/app/components/atoms/TitleAnimation.tsx
+++ b/src/app/components/atoms/TitleAnimation.tsx
@@ -1,38 +1,51 @@
 'use client'
 
+import { faArrowDown } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import gsap from 'gsap'
-import { TextPlugin } from 'gsap/TextPlugin'
-import { useEffect, useRef } from 'react'
+import { useEffect, useLayoutEffect, useRef } from 'react'
 
-gsap.registerPlugin(TextPlugin)
+// タイトルは 2 行構成。JSX から直接描画し、no-JS / reduced-motion でも即時表示する。
+const TITLE_LINES = ['Furugen', 'Island']
+
+// フェード開始状態（opacity:0）をペイント前に確定させ初回フラッシュ（FOUC）を防ぐ。
+// SSR では useLayoutEffect が警告を出すため、サーバー側は useEffect にフォールバックする。
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect
 
 export default function TitleAnimation() {
-  // アニメーション
-  const textRef = useRef<HTMLParagraphElement>(null)
+  const lineRefs = useRef<(HTMLSpanElement | null)[]>([])
   const arrowRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
-    if (textRef.current) {
-      gsap.fromTo(
-        textRef.current,
-        { opacity: 0 },
-        {
-          duration: 1.5,
-          text: 'Furugen<br />Island',
-          ease: 'power4.inOut',
-          parse: true,
-          opacity: 1,
-        },
-      )
+  useIsomorphicLayoutEffect(() => {
+    // prefers-reduced-motion: reduce の場合はアニメーションせず即時表示のままにする。
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      return
     }
+
+    const lines = lineRefs.current.filter(
+      (line): line is HTMLSpanElement => line !== null,
+    )
+    gsap.fromTo(
+      lines,
+      { opacity: 0, y: 16, filter: 'blur(8px)' },
+      {
+        opacity: 1,
+        y: 0,
+        filter: 'blur(0px)',
+        duration: 1,
+        ease: 'power2.out',
+        stagger: 0.15,
+      },
+    )
 
     if (arrowRef.current) {
       gsap.to(arrowRef.current, {
-        y: -10,
+        y: -6,
         repeat: -1,
         yoyo: true,
-        ease: 'power1.inOut',
-        duration: 0.8,
+        ease: 'sine.inOut',
+        duration: 1.6,
       })
     }
   }, [])
@@ -40,11 +53,21 @@ export default function TitleAnimation() {
   return (
     <div className="relative mb-24 h-[80vh]">
       <div
-        className="
-          dm-sans mt-10 max-w-full select-none text-left text-5xl
+        className="dm-sans mt-10 max-w-full select-none text-left text-5xl
           font-bold tracking-widest text-main-black dark:text-night-white md:text-9xl"
-        ref={textRef}
-      ></div>
+      >
+        {TITLE_LINES.map((line, index) => (
+          <span
+            key={line}
+            ref={(el) => {
+              lineRefs.current[index] = el
+            }}
+            className="block"
+          >
+            {line}
+          </span>
+        ))}
+      </div>
       <div className="absolute bottom-10 right-0 flex flex-col items-center">
         <div
           className="select-none text-lg tracking-widest text-main-black dark:text-night-white md:text-2xl"
@@ -56,7 +79,10 @@ export default function TitleAnimation() {
           ref={arrowRef}
           className="mt-3 select-none text-lg text-main-black dark:text-night-white md:text-2xl"
         >
-          ↓
+          <FontAwesomeIcon
+            icon={faArrowDown}
+            className="text-sm md:text-base"
+          />
         </div>
       </div>
     </div>

--- a/src/app/components/molecules/GithubLinkButton.style.test.tsx
+++ b/src/app/components/molecules/GithubLinkButton.style.test.tsx
@@ -1,0 +1,98 @@
+// GitHub リンクボタン（src/app/components/molecules/GithubLinkButton.tsx）の
+// index 配線と stagger 表示契約を固定する単体テスト（Issue #224 UI刷新 2/3 / TDD 先行）。
+//
+// #224 では GithubLinkButton にも index prop を新設し、ヘッダー最後尾として
+// links.length + 1 相当の index を受け取り、index に応じた animation-delay と
+// fill-mode: backwards で他ボタンと揃った段階表示にする。現状は index prop が無く
+// 遅延なしで発火するため、本テストは新設 prop の契約と遅延出力を固定する。
+//
+// GithubLinkButton は next/link と FontAwesome に依存する。next/link は
+// href/className/style を反映する素の <a> へ差し替える（FontAwesome はモック不要）。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は index prop 未対応で animation-delay が無いため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+const linkMock =
+  'data:text/javascript,' +
+  encodeURIComponent(
+    "export default function Link(props){return React.createElement('a',{href:props.href,className:props.className,style:props.style,target:props.target,rel:props.rel},props.children)}",
+  )
+
+const resolveHook = `
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.endsWith('.css')) {
+    return { url: 'data:text/javascript,export default {}', shortCircuit: true }
+  }
+  if (specifier === 'next/link') {
+    return { url: ${JSON.stringify(linkMock)}, shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}
+`
+register(
+  'data:text/javascript,' + encodeURIComponent(resolveHook),
+  import.meta.url,
+)
+
+// tsx は classic JSX runtime へ変換するため React をグローバルに渡す。
+;(globalThis as Record<string, unknown>).React = React
+
+type GithubLinkButtonComponent = React.FC<{ index: number }>
+
+let GithubLinkButton: GithubLinkButtonComponent
+before(async () => {
+  GithubLinkButton = (await import('./GithubLinkButton'))
+    .default as unknown as GithubLinkButtonComponent
+})
+
+const render = (index: number): string =>
+  renderToStaticMarkup(<GithubLinkButton index={index} />)
+
+test('GithubLinkButton: index に応じた animation-delay を出力する', () => {
+  // Given: ヘッダー最後尾（links.length + 1 = 5）に配置される
+  // When: 描画する
+  const html = render(5)
+  // Then: 他ボタンと揃うよう index * 80ms の遅延が付く
+  assert.match(html, /animation-delay:400ms/, 'index=5 → 400ms')
+})
+
+test('GithubLinkButton: 遅延中に一瞬フル表示しないよう fill-mode を backwards にする', () => {
+  // Given/When: 描画する
+  const html = render(5)
+  // Then: animation-fill-mode: backwards
+  assert.match(
+    html,
+    /animation-fill-mode:backwards/,
+    'animation-fill-mode:backwards を含む',
+  )
+})
+
+test('GithubLinkButton: フェードイン演出（animate-fade-in-up）は維持する', () => {
+  // Given/When: 描画する
+  const html = render(5)
+  // Then: 既存のフェードインは残す
+  assert.ok(html.includes('animate-fade-in-up'), 'animate-fade-in-up を含む')
+})
+
+test('GithubLinkButton: Repository ラベルは維持する', () => {
+  // Given/When: 描画する
+  const html = render(5)
+  // Then: 既存の表示内容は変えない
+  assert.ok(html.includes('Repository'), 'Repository を含む')
+})
+
+test('GithubLinkButton: reduced-motion では stagger アニメを無効化する', () => {
+  // Given/When: 描画する
+  const html = render(5)
+  // Then: prefers-reduced-motion を尊重し motion-reduce でアニメを止める
+  assert.ok(
+    html.includes('motion-reduce:animate-none'),
+    'motion-reduce:animate-none を含む',
+  )
+})

--- a/src/app/components/molecules/GithubLinkButton.tsx
+++ b/src/app/components/molecules/GithubLinkButton.tsx
@@ -1,11 +1,18 @@
 import { faGithub } from '@fortawesome/free-brands-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Link from 'next/link'
+import React from 'react'
+import { staggerStyle } from './staggerStyle'
 
-const GithubLinkButton = () => {
+interface GithubLinkButtonProps {
+  index: number
+}
+
+const GithubLinkButton: React.FC<GithubLinkButtonProps> = ({ index }) => {
   return (
     <Link
-      className="mr-auto mt-8 animate-fade-in-up md:mt-0"
+      className="mr-auto mt-8 animate-fade-in-up motion-reduce:animate-none md:mt-0"
+      style={staggerStyle(index)}
       href="https://github.com/motoshifurugen/my_site"
       target="_blank"
       rel="noopener noreferrer"

--- a/src/app/components/molecules/HeaderDropdownButton.style.test.tsx
+++ b/src/app/components/molecules/HeaderDropdownButton.style.test.tsx
@@ -1,0 +1,101 @@
+// ヘッダードロップダウン（src/app/components/molecules/HeaderDropdownButton.tsx）の
+// stagger 表示契約を固定する単体テスト（Issue #224 UI刷新 2/3 / TDD 先行）。
+//
+// #224 はヘッダー各ボタンを index に応じた段階表示（stagger）へ変える。
+// ドロップダウンはヘッダーの links の後に来るため、その index に応じた
+// animation-delay と fill-mode: backwards を持つ。本テストはその契約を固定する。
+//
+// HeaderDropdownButton は next/link と FontAwesome に依存する。FontAwesome は SSR で
+// SVG を描画するためモック不要。next/link は href/className/style を反映する素の <a> へ
+// 差し替える。ルート要素（stagger の style を持つ <div>）自体は Link ではない。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は animation-delay が無いため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+const linkMock =
+  'data:text/javascript,' +
+  encodeURIComponent(
+    "export default function Link(props){return React.createElement('a',{href:props.href,className:props.className,style:props.style},props.children)}",
+  )
+
+const resolveHook = `
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.endsWith('.css')) {
+    return { url: 'data:text/javascript,export default {}', shortCircuit: true }
+  }
+  if (specifier === 'next/link') {
+    return { url: ${JSON.stringify(linkMock)}, shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}
+`
+register(
+  'data:text/javascript,' + encodeURIComponent(resolveHook),
+  import.meta.url,
+)
+
+// tsx は classic JSX runtime へ変換するため React をグローバルに渡す。
+;(globalThis as Record<string, unknown>).React = React
+
+type HeaderDropdownButtonComponent = React.FC<{
+  text: string
+  subItems: { href: string; text: string }[]
+  index: number
+}>
+
+let HeaderDropdownButton: HeaderDropdownButtonComponent
+before(async () => {
+  HeaderDropdownButton = (await import('./HeaderDropdownButton'))
+    .default as unknown as HeaderDropdownButtonComponent
+})
+
+const render = (index: number): string =>
+  renderToStaticMarkup(
+    <HeaderDropdownButton
+      text="遊び"
+      subItems={[{ href: '/game', text: 'ゲーム' }]}
+      index={index}
+    />,
+  )
+
+test('HeaderDropdownButton: index に応じた animation-delay を出力する', () => {
+  // Given: links(4件) の直後（index=4）に配置される
+  // When: 描画する
+  const html = render(4)
+  // Then: index * 80ms の遅延が付く
+  assert.match(html, /animation-delay:320ms/, 'index=4 → 320ms')
+})
+
+test('HeaderDropdownButton: 遅延中に一瞬フル表示しないよう fill-mode を backwards にする', () => {
+  // Given/When: 描画する
+  const html = render(4)
+  // Then: animation-fill-mode: backwards
+  assert.match(
+    html,
+    /animation-fill-mode:backwards/,
+    'animation-fill-mode:backwards を含む',
+  )
+})
+
+test('HeaderDropdownButton: フェードイン演出（animate-fade-in-up）は維持する', () => {
+  // Given/When: 描画する
+  const html = render(4)
+  // Then: 既存のフェードインは残す
+  assert.ok(html.includes('animate-fade-in-up'), 'animate-fade-in-up を含む')
+})
+
+test('HeaderDropdownButton: reduced-motion では stagger アニメを無効化する', () => {
+  // Given/When: 描画する
+  const html = render(4)
+  // Then: prefers-reduced-motion を尊重し motion-reduce でアニメを止める
+  assert.ok(
+    html.includes('motion-reduce:animate-none'),
+    'motion-reduce:animate-none を含む',
+  )
+})

--- a/src/app/components/molecules/HeaderDropdownButton.tsx
+++ b/src/app/components/molecules/HeaderDropdownButton.tsx
@@ -4,6 +4,7 @@ import { faChevronDown } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Link from 'next/link'
 import React, { useState } from 'react'
+import { staggerStyle } from './staggerStyle'
 
 interface SubMenuItem {
   href: string
@@ -24,7 +25,10 @@ const HeaderDropdownButton: React.FC<HeaderDropdownButtonProps> = ({
   const [isOpen, setIsOpen] = useState(false)
 
   return (
-    <div className="mt-6 flex animate-fade-in-up items-center pr-8 md:mr-10 md:mt-0 md:pr-0">
+    <div
+      className="mt-6 flex animate-fade-in-up items-center pr-8 motion-reduce:animate-none md:mr-10 md:mt-0 md:pr-0"
+      style={staggerStyle(index)}
+    >
       <div
         className="relative inline-block ml-auto md:ml-0 cursor-pointer"
         onMouseEnter={() => window.innerWidth >= 768 && setIsOpen(true)}

--- a/src/app/components/molecules/HeaderLinkButton.style.test.tsx
+++ b/src/app/components/molecules/HeaderLinkButton.style.test.tsx
@@ -1,0 +1,110 @@
+// ヘッダーリンク（src/app/components/molecules/HeaderLinkButton.tsx）の
+// stagger 表示契約を固定する単体テスト（Issue #224 UI刷新 2/3 / TDD 先行）。
+//
+// #224 はヘッダーの各ボタンが同時に animate-fade-in-up で発火していたのを、
+// 既に配線済みの index prop を使って左から順に段階表示（stagger）へ変える。
+// 各ボタンは style={{ animationDelay: `${index * 80}ms`, animationFillMode:
+// 'backwards' }} を持ち、遅延中は fadeInUp の 0% 状態を保持する
+// （fill-mode 未指定だと遅延中に一瞬フル表示される）。
+// 本テストはこの index → animation-delay の対応と fill-mode を固定する。
+//
+// HeaderLinkButton は next/link に依存するため、href/className/style を素の <a> へ
+// 反映するモックへ resolve フックで張り替える（yomoyo/page.test.tsx と同じ無 import パターン）。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は animation-delay が無いため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+// next/link を href/className/style/子要素のみ反映する素の <a> へ差し替える。
+// data: URL モジュールは bare specifier 'react' を解決できないため、
+// テストが設定する globalThis.React（classic JSX runtime 用）を参照する。
+const linkMock =
+  'data:text/javascript,' +
+  encodeURIComponent(
+    "export default function Link(props){return React.createElement('a',{href:props.href,className:props.className,style:props.style,target:props.target,rel:props.rel},props.children)}",
+  )
+
+const resolveHook = `
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.endsWith('.css')) {
+    return { url: 'data:text/javascript,export default {}', shortCircuit: true }
+  }
+  if (specifier === 'next/link') {
+    return { url: ${JSON.stringify(linkMock)}, shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}
+`
+register(
+  'data:text/javascript,' + encodeURIComponent(resolveHook),
+  import.meta.url,
+)
+
+// tsx は classic JSX runtime へ変換するため React をグローバルに渡す。
+;(globalThis as Record<string, unknown>).React = React
+
+type HeaderLinkButtonComponent = React.FC<{
+  href: string
+  text: string
+  index: number
+}>
+
+let HeaderLinkButton: HeaderLinkButtonComponent
+before(async () => {
+  HeaderLinkButton = (await import('./HeaderLinkButton'))
+    .default as unknown as HeaderLinkButtonComponent
+})
+
+const render = (index: number): string =>
+  renderToStaticMarkup(
+    <HeaderLinkButton href="/blog" text="ブログ" index={index} />,
+  )
+
+test('HeaderLinkButton: index に応じた animation-delay を出力する', () => {
+  // Given: リストの 3 番目（index=2）に配置される
+  // When: 描画する
+  const html = render(2)
+  // Then: 左から順に出現するよう index * 80ms の遅延が付く
+  assert.match(html, /animation-delay:160ms/, 'index=2 → 160ms')
+})
+
+test('HeaderLinkButton: 先頭（index=0）は遅延なし（0ms）で出現する', () => {
+  // Given: リスト先頭
+  // When: 描画する
+  const html = render(0)
+  // Then: 先頭は遅延ゼロ
+  assert.match(html, /animation-delay:0ms/, 'index=0 → 0ms')
+})
+
+test('HeaderLinkButton: 遅延中に一瞬フル表示しないよう fill-mode を backwards にする', () => {
+  // Given/When: 描画する
+  const html = render(1)
+  // Then: animation-fill-mode: backwards で遅延中も 0% 状態を保つ
+  assert.match(
+    html,
+    /animation-fill-mode:backwards/,
+    'animation-fill-mode:backwards を含む',
+  )
+})
+
+test('HeaderLinkButton: フェードイン演出（animate-fade-in-up）は維持する', () => {
+  // Given/When: 描画する
+  const html = render(1)
+  // Then: 既存のフェードインアニメーションは残す
+  assert.ok(html.includes('animate-fade-in-up'), 'animate-fade-in-up を含む')
+})
+
+test('HeaderLinkButton: reduced-motion では stagger アニメを無効化する', () => {
+  // Given/When: 描画する
+  const html = render(1)
+  // Then: prefers-reduced-motion を尊重し motion-reduce でアニメを止める
+  assert.ok(
+    html.includes('motion-reduce:animate-none'),
+    'motion-reduce:animate-none を含む',
+  )
+})

--- a/src/app/components/molecules/HeaderLinkButton.tsx
+++ b/src/app/components/molecules/HeaderLinkButton.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import React from 'react'
+import { staggerStyle } from './staggerStyle'
 
 interface HeaderLinkButtonProps {
   href: string
@@ -14,8 +15,8 @@ const HeaderLinkButton: React.FC<HeaderLinkButtonProps> = ({
 }) => {
   return (
     <Link
-      key={index}
-      className="mt-6 flex animate-fade-in-up items-center pr-8 hover:opacity-50 md:mr-10 md:mt-0 md:pr-0"
+      className="mt-6 flex animate-fade-in-up items-center pr-8 hover:opacity-50 motion-reduce:animate-none md:mr-10 md:mt-0 md:pr-0"
+      style={staggerStyle(index)}
       href={href}
     >
       <span className="noto-sans-jp ml-auto select-none text-lg font-bold text-main-black dark:text-night-white md:ml-0 md:text-base">

--- a/src/app/components/molecules/staggerStyle.ts
+++ b/src/app/components/molecules/staggerStyle.ts
@@ -1,0 +1,13 @@
+import type { CSSProperties } from 'react'
+
+// ヘッダー各ボタンを左から順に段階表示するための遅延ステップ（ms）。
+// この値がヘッダー stagger 全体の間隔を決める単一の情報源。
+const STAGGER_STEP_MS = 80
+
+// index に応じた stagger 用インラインスタイルを返す。
+// 遅延中は fadeInUp の 0% 状態を保持するため fill-mode を backwards にする
+// （未指定だと遅延中に一瞬フル表示されてしまう）。
+export const staggerStyle = (index: number): CSSProperties => ({
+  animationDelay: `${index * STAGGER_STEP_MS}ms`,
+  animationFillMode: 'backwards',
+})

--- a/src/app/components/organisms/MessageBoard.style.test.tsx
+++ b/src/app/components/organisms/MessageBoard.style.test.tsx
@@ -1,0 +1,162 @@
+// MessageBoard（お知らせ欄）の刷新後スタイル契約を固定する単体テスト
+// （Issue #224 UI刷新 2/3 / TDD 先行）。
+//
+// #224 は「新着情報」表組み風の罫線リストを、罫線なし＋余白＋淡い hover 背景の
+// 今風リストへ更新する。カテゴリバッジは角ばったグレー（bg-gray px-4 py-1）から
+// rounded-full の淡色地＋濃色文字へ変え、blogUpdate=teal 系 / notification=orange 系で
+// 色分けし、ダークモードにも対応する。日付は tabular-nums の小さめ二次色にする。
+// 本テストはこれらの className 契約を静的マークアップ上で固定する。
+//
+// 既存の MessageBoard.test.tsx と同じく node 組み込み node:test と
+// react-dom/server の renderToStaticMarkup、I18nProvider のみで構成する。
+// MessageBoard は next/link を使わず素の <a> を描画するためリンクモックは不要。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は border-gray / bg-gray バッジのままのため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { I18nProvider } from '../../../i18n/context'
+import { translations } from '../../../i18n/translations'
+import MessageBoard from './MessageBoard'
+;(globalThis as Record<string, unknown>).React = React
+
+function renderBoard(locale: 'ja' | 'en'): string {
+  return renderToStaticMarkup(
+    <I18nProvider initialLocale={locale}>
+      <MessageBoard />
+    </I18nProvider>,
+  )
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+// カテゴリ名を内包するバッジ <span> の class 属性を取り出す。
+// 色分け（teal / orange）とバッジ形状（rounded-full）をカテゴリ単位で検証するため。
+function badgeClassForCategory(html: string, categoryText: string): string {
+  const match = html.match(
+    new RegExp(
+      '<span class="([^"]*)"[^>]*>' + escapeRegExp(categoryText) + '</span>',
+    ),
+  )
+  assert.ok(match, `カテゴリ「${categoryText}」のバッジ span が存在する`)
+  return match![1]
+}
+
+test('MessageBoard: 罫線区切り（border-gray）を廃止する', () => {
+  // Given/When: お知らせ欄を描画する
+  const html = renderBoard('ja')
+  // Then: 2000 年代風の罫線区切りに使われていた border-gray が残っていない
+  assert.ok(!html.includes('border-gray'), 'border-gray を含まない')
+})
+
+test('MessageBoard: 行区切りを淡い hover 背景で表現する', () => {
+  // Given/When: お知らせ欄を描画する
+  const html = renderBoard('ja')
+  // Then: 罫線に代えて hover 時の背景変化で区切る
+  assert.match(html, /hover:bg-/, 'hover:bg- を含む')
+})
+
+test('MessageBoard: カテゴリバッジを rounded-full にする', () => {
+  // Given/When: お知らせ欄を描画する
+  const html = renderBoard('ja')
+  // Then: 角ばったバッジ（旧 bg-gray px-4 py-1）ではなく丸ピル型になる
+  const notification = badgeClassForCategory(
+    html,
+    translations.ja.announcements.categories.notification,
+  )
+  const blogUpdate = badgeClassForCategory(
+    html,
+    translations.ja.announcements.categories.blogUpdate,
+  )
+  assert.ok(
+    notification.includes('rounded-full'),
+    'notification が rounded-full',
+  )
+  assert.ok(blogUpdate.includes('rounded-full'), 'blogUpdate が rounded-full')
+})
+
+test('MessageBoard: 旧グレーバッジ（bg-gray）を残さない', () => {
+  // Given/When: お知らせ欄を描画する
+  const html = renderBoard('ja')
+  // Then: 淡色地バッジへ刷新され、角ばったグレー地は使われていない
+  assert.ok(!html.includes('bg-gray'), 'bg-gray を含まない')
+})
+
+test('MessageBoard: blogUpdate バッジは teal 系の淡トーンにする', () => {
+  // Given/When: お知らせ欄を描画する
+  const html = renderBoard('ja')
+  // Then: ブログ更新カテゴリは teal 系トークンで色分けされる
+  const badge = badgeClassForCategory(
+    html,
+    translations.ja.announcements.categories.blogUpdate,
+  )
+  assert.match(badge, /teal/, 'teal 系トークンを含む')
+})
+
+test('MessageBoard: notification バッジは orange 系の淡トーンにする', () => {
+  // Given/When: お知らせ欄を描画する
+  const html = renderBoard('ja')
+  // Then: お知らせカテゴリは orange 系トークンで色分けされる
+  const badge = badgeClassForCategory(
+    html,
+    translations.ja.announcements.categories.notification,
+  )
+  assert.match(badge, /orange/, 'orange 系トークンを含む')
+})
+
+test('MessageBoard: カテゴリごとにバッジのクラスを変える（色分け）', () => {
+  // Given/When: お知らせ欄を描画する
+  const html = renderBoard('ja')
+  // Then: blogUpdate と notification のバッジ className が異なる
+  const notification = badgeClassForCategory(
+    html,
+    translations.ja.announcements.categories.notification,
+  )
+  const blogUpdate = badgeClassForCategory(
+    html,
+    translations.ja.announcements.categories.blogUpdate,
+  )
+  assert.notEqual(notification, blogUpdate, 'カテゴリ別に異なるバッジ配色')
+})
+
+test('MessageBoard: バッジはダークモード配色（dark:）に対応する', () => {
+  // Given/When: お知らせ欄を描画する
+  const html = renderBoard('ja')
+  // Then: 両カテゴリのバッジにダーク用 variant が付く（ダークで破綻させない）
+  const notification = badgeClassForCategory(
+    html,
+    translations.ja.announcements.categories.notification,
+  )
+  const blogUpdate = badgeClassForCategory(
+    html,
+    translations.ja.announcements.categories.blogUpdate,
+  )
+  assert.match(notification, /dark:/, 'notification に dark: variant')
+  assert.match(blogUpdate, /dark:/, 'blogUpdate に dark: variant')
+})
+
+test('MessageBoard: 日付を tabular-nums で桁揃えする', () => {
+  // Given/When: お知らせ欄を描画する
+  const html = renderBoard('ja')
+  // Then: 日付は等幅数字で小さめ二次色にする
+  assert.match(html, /tabular-nums/, 'tabular-nums を含む')
+})
+
+test('MessageBoard: 既存のお知らせ本文・リンクは維持する', () => {
+  // Given/When: お知らせ欄を描画する（機能・表示件数は不変）
+  const html = renderBoard('ja')
+  // Then: 刷新後もタイトルと link 付きお知らせの linkText を描画する
+  assert.ok(
+    html.includes(translations.ja.announcements.items['2025-04-22'].title),
+    'お知らせタイトルを描画する',
+  )
+  assert.ok(
+    html.includes(translations.ja.announcements.items['2025-04-22'].linkText),
+    'link 付きお知らせの linkText を描画する',
+  )
+})

--- a/src/app/components/organisms/MessageBoard.test.tsx
+++ b/src/app/components/organisms/MessageBoard.test.tsx
@@ -25,8 +25,9 @@ test('MessageBoard: ja ロケールで announcement タイトルを描画する'
   // Given/When: 日本語で描画する
   const html = renderBoard('ja')
   // Then: items から解決したタイトルが本文に含まれる
+  // 2025-04-22 は announcementsData に存在する（旧 2025-09-27 はデータから除かれている）。
   assert.ok(
-    html.includes(translations.ja.announcements.items['2025-09-27'].title),
+    html.includes(translations.ja.announcements.items['2025-04-22'].title),
   )
 })
 
@@ -35,16 +36,16 @@ test('MessageBoard: en ロケールで announcement タイトルを描画する'
   const html = renderBoard('en')
   // Then: items から解決した英語タイトルが本文に含まれる
   assert.ok(
-    html.includes(translations.en.announcements.items['2025-09-27'].title),
+    html.includes(translations.en.announcements.items['2025-04-22'].title),
   )
 })
 
 test('MessageBoard: link を持つ announcement の linkText を描画する', () => {
   // Given/When: 日本語で描画する
   const html = renderBoard('ja')
-  // Then: link 付きお知らせの linkText（短歌）がリンク表示される
+  // Then: link 付きお知らせの linkText がリンク表示される
   assert.ok(
-    html.includes(translations.ja.announcements.items['2025-09-27'].linkText),
+    html.includes(translations.ja.announcements.items['2025-04-22'].linkText),
   )
 })
 

--- a/src/app/components/organisms/MessageBoard.tsx
+++ b/src/app/components/organisms/MessageBoard.tsx
@@ -1,28 +1,34 @@
 'use client'
 
 import { useI18n } from '@/i18n'
-import { announcementsData } from './MessageData'
+import { announcementsData, type AnnouncementData } from './MessageData'
+
+// カテゴリごとのバッジ配色（淡色地＋濃色文字、ダークモード対応）。
+// blogUpdate=teal 系 / notification=orange 系で視覚的に区別する。
+const categoryBadgeClasses: Record<AnnouncementData['categoryKey'], string> = {
+  blogUpdate:
+    'bg-teal-50 text-teal-700 dark:bg-teal-900/40 dark:text-night-teal',
+  notification:
+    'bg-orange/10 text-orange dark:bg-night-orange/20 dark:text-night-orange',
+}
 
 const MessageBoard = () => {
   const { t } = useI18n()
 
-  // if (announcementsData.length > 5) {
-  //   throw new Error('お知らせは5件までです。')
-  // }
-
   return (
-    <div className="px-2 py-4 my-20 bg-white/15 dark:bg-night-black/50 rounded-md">
+    <div className="my-20 rounded-md bg-white/15 px-2 py-4 dark:bg-night-black/50">
       <h3 className="mb-2 select-none">{t.announcements.title}</h3>
       <ul className="m-0 list-none p-0">
         {announcementsData.map((announcement, index) => (
-          <li
-            key={index}
-            className={`border-b border-gray ${index === 0 ? 'border-t' : ''}`}
-          >
-            <div className="flex select-none flex-wrap items-center border-b border-gray p-4 text-main-black no-underline md:flex-nowrap">
-              <p className="m-0 min-w-[80px] text-sm">{announcement.date}</p>
+          <li key={index}>
+            <div className="flex select-none flex-wrap items-center gap-x-4 gap-y-1 rounded-md p-4 text-main-black transition-colors hover:bg-main-black/5 dark:text-night-white dark:hover:bg-night-white/5 md:flex-nowrap">
+              <p className="m-0 min-w-[80px] text-xs tabular-nums text-main-black/60 dark:text-night-white/60">
+                {announcement.date}
+              </p>
               <p className="m-0 min-w-[120px] text-center">
-                <span className="inline-block bg-gray px-4 py-1 text-center text-xs leading-none text-main-black">
+                <span
+                  className={`inline-block rounded-full px-3 py-1 text-center text-xs font-medium leading-none ${categoryBadgeClasses[announcement.categoryKey]}`}
+                >
                   {t.announcements.categories[announcement.categoryKey]}
                 </span>
               </p>

--- a/src/app/components/templates/Header.stagger.test.tsx
+++ b/src/app/components/templates/Header.stagger.test.tsx
@@ -1,0 +1,106 @@
+// Header → 各ボタンへの stagger index 伝搬をロックするインテグレーションテスト
+// （Issue #224 UI刷新 2/3 / TDD 先行）。
+//
+// #224 はヘッダーの nav 内ボタン（HeaderLinkButton × links / HeaderDropdownButton /
+// GithubLinkButton）を左から順に段階表示する。特に GithubLinkButton は現状 index が
+// 未配線で単独発火しているため、Header 側で index={links.length + 1} を渡すよう
+// 配線を追加する必要がある。本テストは Header → GithubLinkButton までの index 伝搬
+// （呼び出しチェーン末端の animation-delay 出力）を固定する。
+//
+// links は 4 件（profile / blog / skills / contact）。よって:
+//   - HeaderLinkButton: index 0..3 → 0,80,160,240ms
+//   - HeaderDropdownButton(遊び): index = links.length = 4 → 320ms
+//   - GithubLinkButton(Repository): index = links.length + 1 = 5 → 400ms
+//
+// Header は next/navigation(usePathname) と next/link に依存するため resolve フックで
+// モックへ張り替える。usePathname はトップページ相当の '/' を返す。
+// ThemeSwitch / LanguageSwitcher（react-icons）や FontAwesome は SSR で問題なく描画される。
+// renderToStaticMarkup は effect を実行しないため useEffect(scrollTo 等) は動かない。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は GithubLinkButton へ index 未配線のため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+const linkMock =
+  'data:text/javascript,' +
+  encodeURIComponent(
+    "export default function Link(props){return React.createElement('a',{href:props.href,className:props.className,style:props.style,target:props.target,rel:props.rel},props.children)}",
+  )
+
+const navMock =
+  'data:text/javascript,' +
+  encodeURIComponent("export function usePathname(){return '/'}")
+
+const resolveHook = `
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.endsWith('.css')) {
+    return { url: 'data:text/javascript,export default {}', shortCircuit: true }
+  }
+  if (specifier === 'next/link') {
+    return { url: ${JSON.stringify(linkMock)}, shortCircuit: true }
+  }
+  if (specifier === 'next/navigation') {
+    return { url: ${JSON.stringify(navMock)}, shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}
+`
+register(
+  'data:text/javascript,' + encodeURIComponent(resolveHook),
+  import.meta.url,
+)
+
+// tsx は classic JSX runtime へ変換するため React をグローバルに渡す。
+;(globalThis as Record<string, unknown>).React = React
+
+let Header: React.FC
+let I18nProvider: React.FC<{ children: React.ReactNode }>
+before(async () => {
+  Header = (await import('./Header')).default as unknown as React.FC
+  I18nProvider = (await import('../../../i18n/context'))
+    .I18nProvider as unknown as React.FC<{ children: React.ReactNode }>
+})
+
+const render = (): string =>
+  renderToStaticMarkup(
+    <I18nProvider>
+      <Header />
+    </I18nProvider>,
+  )
+
+test('Header: 例外なく描画される', () => {
+  // Given/When/Then: stagger 配線後も SSR 描画で throw しない
+  assert.doesNotThrow(() => render())
+})
+
+test('Header: 先頭リンクは遅延なし（0ms）で出現する', () => {
+  // Given/When: ヘッダーを描画する
+  const html = render()
+  // Then: nav 先頭リンク（index=0）は遅延ゼロ
+  assert.match(html, /animation-delay:0ms/, '先頭リンクが 0ms')
+})
+
+test('Header: ドロップダウンは links の直後（320ms）で出現する', () => {
+  // Given/When: ヘッダーを描画する
+  const html = render()
+  // Then: index = links.length = 4 → 320ms
+  assert.match(html, /animation-delay:320ms/, 'ドロップダウンが 320ms')
+})
+
+test('Header: GithubLinkButton へ index を伝搬し最後尾（400ms）で出現させる', () => {
+  // GithubLinkButton は従来 index 未配線で単独発火していた。Header が
+  // index={links.length + 1}=5 を渡すことで最後尾の遅延（400ms）が付く。
+  // Given/When: ヘッダーを描画する
+  const html = render()
+  // Then: Repository リンク（GithubLinkButton）に 400ms の遅延が伝搬している
+  assert.match(
+    html,
+    /<a[^>]*animation-delay:400ms[^>]*>[\s\S]*?Repository/,
+    'Repository リンクに animation-delay:400ms が伝搬している',
+  )
+})

--- a/src/app/components/templates/Header.tsx
+++ b/src/app/components/templates/Header.tsx
@@ -106,7 +106,7 @@ const Header = () => {
             </div>
 
             <div className="ml-auto mt-6 pr-7 md:m-0 md:pr-0">
-              <GithubLinkButton />
+              <GithubLinkButton index={links.length + 1} />
             </div>
 
             {/* デスクトップでのテーマ・言語切り替え */}


### PR DESCRIPTION
## 概要
GitHub Issue #224「UI刷新(2/3): トップページ刷新（お知らせ欄・ヒーロー・ヘッダーstagger）」を takt（default workflow: テスト先行）で実装。

## 背景

トップページが「一昔前のホームページ」に見える3大要因（お知らせ表組み・タイプライター演出・一斉フェードイン）を、**レイアウト構造と世界観は変えずに**今風の手触りへ更新する。

前提: デザイントークン刷新イシュー（配色・影・角丸・フォント）がマージ済みであること。新トークンを使うこと。

## 変更内容

### 1. お知らせ欄の刷新（`src/app/components/organisms/MessageBoard.tsx`）
最重要。現状は `border-t`/`border-b border-gray` の罫線区切り行リスト＋角ばったグレーバッジで、2000年代の「新着情報」表組みに見える。
- 罫線区切りをやめ、行間の余白＋`hover:bg-*`（ごく淡い背景）での区切りに変更
- カテゴリバッジ（現: `bg-gray px-4 py-1 text-xs`）を `rounded-full` の淡色地＋濃色文字へ。`blogUpdate`=teal系薄トーン / `notification`=orange系薄トーンで色分け（ダークモード対応必須）
- 日付は `tabular-nums` で小さめ・二次色（グレー）に
- リスト構造・表示件数・「もっと見る」等の既存機能はそのまま

### 2. ヒーロー演出の更新（`src/app/components/atoms/TitleAnimation.tsx`）
- GSAP TextPlugin のタイプライター（1文字ずつ描画）をやめ、**opacity + わずかな blur + 軽い上方向移動のフェードイン**に差し替え（GSAP のまま実装してよい。行ごとに僅かな時間差があると良い）
- 縦書き "scroll" + テキスト文字 `↓` のバウンドは、`↓` を細い線の SVG/アイコン（FontAwesome の faArrowDown 等でも可）に置き換え、動きはより控えめなループ（小さい振幅・ゆっくり）に
- `prefers-reduced-motion` を尊重（reduce 時はアニメなしで即表示）

### 3. ヘッダーの stagger 表示
- `HeaderLinkButton.tsx` / `HeaderDropdownButton.tsx` / `GithubLinkButton.tsx` が全て同時に `animate-fade-in-up` で発火している
- 既に `index` prop が配線されているので、`style={{ animationDelay: `${index * 80}ms` }}` （+ `animation-fill-mode: backwards`）で左から順に段階表示にする
- GithubLinkButton にも links.length+1 相当の index を渡す

## 完了条件
- `npm run build` 成功、`npm run lint` パス
- トップページ表示時: タイトルがフェードイン、ヘッダーが左から順に出現、お知らせが罫線なしの今風リストになっている
- ダークモードでお知らせバッジの色が破綻しない
- `prefers-reduced-motion: reduce` でタイトルが即時表示される

---
Workflow `default` completed successfully.

Closes #224

🤖 Generated with takt + Claude Code