### PR TITLE
[#225] UI刷新(3/3): 細部刷新（ボタン・フッター・タグ/チップ）

### DIFF
--- a/src/app/components/atoms/Chip.style.test.tsx
+++ b/src/app/components/atoms/Chip.style.test.tsx
@@ -1,0 +1,66 @@
+// Chip を Tags と角丸・パディング・フォントサイズで統一する className 契約を
+// 固定する単体テスト（Issue #225 UI刷新 3/3 / TDD 先行）。
+//
+// #225 は Chip の角丸を rounded-xl → rounded-full に、フォントを md:text-sm 併用から
+// text-xs 単一へ統一する（Tags と揃える）。Chip は React のみに依存し CSS Module も
+// next/* も import しないため追加の resolve フックは不要。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は rounded-xl / md:text-sm のままのため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+;(globalThis as Record<string, unknown>).React = React
+
+let Chip: React.FC<{ children: React.ReactNode; className?: string }>
+before(async () => {
+  Chip = (await import('./Chip')).default as unknown as React.FC<{
+    children: React.ReactNode
+    className?: string
+  }>
+})
+
+const render = (): string =>
+  renderToStaticMarkup(<Chip className="bg-gray">サンプル</Chip>)
+
+test('Chip: 角丸を rounded-full に統一する', () => {
+  // Given/When: Chip を描画する
+  const html = render()
+  // Then: 角丸が rounded-full に統一されている（Tags と揃える）
+  assert.ok(html.includes('rounded-full'), 'rounded-full を含む')
+})
+
+test('Chip: 旧角丸 rounded-xl を残さない', () => {
+  // Given/When: Chip を描画する
+  const html = render()
+  // Then: 旧来の rounded-xl は使われていない
+  assert.ok(!html.includes('rounded-xl'), 'rounded-xl を含まない')
+})
+
+test('Chip: フォントサイズを text-xs に統一し md:text-sm を残さない', () => {
+  // Given/When: Chip を描画する
+  const html = render()
+  // Then: md:text-sm は使わず text-xs 単一に統一されている
+  assert.ok(!html.includes('md:text-sm'), 'md:text-sm を含まない')
+  assert.ok(html.includes('text-xs'), 'text-xs を含む')
+})
+
+test('Chip: パディングを Tags と同一の px-3 py-1 に統一する', () => {
+  // Given/When: Chip を描画する
+  const html = render()
+  // Then: Tags と同じ px-3 py-1（Issue #225 完了条件のパディング統一）
+  assert.ok(html.includes('px-3'), 'px-3 を含む')
+  assert.ok(html.includes('py-1'), 'py-1 を含む')
+  // Then: Tags と食い違う旧値（px-2.5 / py-1.5）を残さない
+  assert.ok(!html.includes('px-2.5'), 'px-2.5 を含まない')
+  assert.ok(!html.includes('py-1.5'), 'py-1.5 を含まない')
+})
+
+test('Chip: 渡した className はパススルーされる', () => {
+  // Given/When: className を渡して Chip を描画する
+  const html = render()
+  // Then: 呼び出し元の色指定などがそのまま反映される
+  assert.ok(html.includes('bg-gray'), '渡した className を含む')
+})

--- a/src/app/components/atoms/Chip.tsx
+++ b/src/app/components/atoms/Chip.tsx
@@ -8,7 +8,7 @@ interface ChipProps {
 const Chip: React.FC<ChipProps> = ({ children, className = '' }) => {
   return (
     <span
-      className={`noto-sans-jp ml-2 inline-block rounded-xl px-3 py-1 text-xs font-semibold md:text-sm ${className}`}
+      className={`noto-sans-jp ml-2 inline-block rounded-full px-3 py-1 text-xs font-semibold ${className}`}
     >
       {children}
     </span>

--- a/src/app/components/atoms/SubmitButton.style.test.tsx
+++ b/src/app/components/atoms/SubmitButton.style.test.tsx
@@ -1,0 +1,99 @@
+// SubmitButton の刷新（inset 擬似ボーダー撤去・塗りボタン化・タイポ緩和・
+// パディング縮小・hover を色深化＋軽い浮き上がりに）の className 契約を固定する
+// 単体テスト（Issue #225 UI刷新 3/3 / TDD 先行）。
+//
+// SubmitButton は React のみに依存し、CSS Module も next/* も import しないため、
+// 追加の resolve フックは不要。classic JSX runtime のため React をグローバルに渡す。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は inset 影・uppercase tracking-widest・px-20/px-32 のままのため RED、
+// 実装後に GREEN になることを期待する。
+
+import assert from 'node:assert/strict'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+;(globalThis as Record<string, unknown>).React = React
+
+let SubmitButton: React.FC<{ children: React.ReactNode }>
+before(async () => {
+  SubmitButton = (await import('./SubmitButton'))
+    .default as unknown as React.FC<{ children: React.ReactNode }>
+})
+
+const render = (): string =>
+  renderToStaticMarkup(<SubmitButton>送信する</SubmitButton>)
+
+test('SubmitButton: inset 影による擬似ボーダーを撤去する', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: inset 影の擬似ボーダー（shadow-[inset_0_0_0_...]）を含まない
+  assert.ok(!html.includes('inset_0_0_0'), 'inset_0_0_0 を含まない')
+})
+
+test('SubmitButton: uppercase を撤去する', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: 英字を強制大文字化する uppercase を含まない
+  assert.ok(!html.includes('uppercase'), 'uppercase を含まない')
+})
+
+test('SubmitButton: tracking-widest を緩和する', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: 過度な字間 tracking-widest は使わない
+  assert.ok(!html.includes('tracking-widest'), 'tracking-widest を含まない')
+})
+
+test('SubmitButton: 字間は tracking-wide 程度に緩和する', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: tracking-widest ではない tracking-wide が付与されている
+  assert.match(html, /tracking-wide(?![a-z])/, 'tracking-wide を含む')
+})
+
+test('SubmitButton: 過大パディング px-20 を縮小する', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: px-20 を含まない（px-10 前後へ縮小）
+  assert.ok(!html.includes('px-20'), 'px-20 を含まない')
+})
+
+test('SubmitButton: 過大パディング md:px-32 を縮小する', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: px-32 を含まない
+  assert.ok(!html.includes('px-32'), 'px-32 を含まない')
+})
+
+test('SubmitButton: hover は全反転（hover:bg-main-black）にしない', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: 背景を黒へ全反転する hover:bg-main-black を含まない
+  assert.ok(
+    !html.includes('hover:bg-main-black'),
+    'hover:bg-main-black を含まない',
+  )
+})
+
+test('SubmitButton: hover で軽く浮き上がる（hover:-translate-y）', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: ホバー時に上方向へ移動する軽い浮き上がり演出がある
+  assert.match(html, /hover:-translate-y-/, 'hover:-translate-y- を含む')
+})
+
+test('SubmitButton: 無用化した内側 <p> ラッパを持たない', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: 塗りボタン化で不要になった <p>（button 内の不正な入れ子）を残さない
+  assert.ok(!html.includes('<p'), '<p> を含まない')
+})
+
+test('SubmitButton: 文字色・太字クラスを button に集約する', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: font-bold と text-main-white が（<p> ではなく）button 上に付与されている
+  assert.ok(html.includes('font-bold'), 'font-bold を含む')
+  assert.ok(html.includes('text-main-white'), 'text-main-white を含む')
+})

--- a/src/app/components/atoms/SubmitButton.tsx
+++ b/src/app/components/atoms/SubmitButton.tsx
@@ -9,16 +9,13 @@ const SubmitButton: React.FC<SubmitButtonProps> = ({ children }) => {
     <button
       type="submit"
       className="
-        group
-        my-10 rounded-3xl
-        px-20 py-4
-        uppercase tracking-widest
-        shadow-[inset_0_0_0_2px_#4A4A4A] transition duration-300
-        hover:bg-main-black dark:shadow-[inset_0_0_0_2px_#E0E0E0] dark:hover:bg-main-white md:px-32"
+        my-10 rounded-full
+        bg-teal px-10 py-4
+        font-bold tracking-wide text-main-white shadow-card transition duration-300
+        hover:-translate-y-0.5 hover:bg-teal-600 hover:shadow-card-hover
+        dark:bg-night-teal dark:hover:bg-teal-400"
     >
-      <p className="bg-transparent font-bold text-main-black transition duration-300 group-hover:text-main-white dark:text-night-white dark:group-hover:text-main-black">
-        {children}
-      </p>
+      {children}
     </button>
   )
 }

--- a/src/app/components/molecules/Tags.style.test.tsx
+++ b/src/app/components/molecules/Tags.style.test.tsx
@@ -1,0 +1,111 @@
+// Tags のトークン化（日本語ハードコードの色分岐をマップ化・rounded-full 淡色地＋
+// 濃色文字）の className 契約を固定する単体テスト（Issue #225 UI刷新 3/3 / TDD 先行）。
+//
+// #225 は Tags の見た目を rounded → rounded-full、text-xxs → text-xs、
+// bg-teal/bg-orange の濃色地＋白文字 → 淡色地＋濃色文字へ更新する。色分岐は
+// `ブログ`/`短編小説` を特別扱い（orange 系）し、他はデフォルト（teal-50 系）にする。
+// 本テストは「タグ種別ごとに異なる淡色トークンが付く」という観測可能な振る舞いを固定する
+// （三項ハードコードか Record マップかという内部実装ではなく、レンダリング結果を検証する）。
+//
+// 既存の BlogCard.style.test.tsx と同じく、node:test と renderToStaticMarkup で構成し、
+// next/navigation(useRouter) は resolve フックでモックへ張り替える。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は rounded / text-xxs / 濃色地のままのため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+const navMock =
+  'data:text/javascript,' +
+  encodeURIComponent(
+    'export function useRouter(){return {push(){},replace(){},prefetch(){},back(){},forward(){},refresh(){}}}',
+  )
+
+const resolveHook = `
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.endsWith('.css')) {
+    return { url: 'data:text/javascript,export default {}', shortCircuit: true }
+  }
+  if (specifier === 'next/navigation') {
+    return { url: ${JSON.stringify(navMock)}, shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}
+`
+register(
+  'data:text/javascript,' + encodeURIComponent(resolveHook),
+  import.meta.url,
+)
+;(globalThis as Record<string, unknown>).React = React
+
+let Tags: React.FC<{ tags: string[] }>
+before(async () => {
+  Tags = (await import('./Tags')).default as unknown as React.FC<{
+    tags: string[]
+  }>
+})
+
+const renderTags = (tags: string[]): string =>
+  renderToStaticMarkup(<Tags tags={tags} />)
+
+test('Tags: 角丸を rounded-full にする', () => {
+  // Given/When: 技術タグを描画する
+  const html = renderTags(['React'])
+  // Then: 角丸が rounded-full になっている
+  assert.ok(html.includes('rounded-full'), 'rounded-full を含む')
+})
+
+test('Tags: 旧極小フォント text-xxs を残さない', () => {
+  // Given/When: 技術タグを描画する
+  const html = renderTags(['React'])
+  // Then: text-xxs は使わず text-xs に統一されている
+  assert.ok(!html.includes('text-xxs'), 'text-xxs を含まない')
+  assert.ok(html.includes('text-xs'), 'text-xs を含む')
+})
+
+test('Tags: 濃色地＋白文字（text-main-white）をやめる', () => {
+  // Given/When: 技術タグを描画する
+  const html = renderTags(['React'])
+  // Then: 淡色地＋濃色文字化に伴い白文字固定は使われていない
+  assert.ok(!html.includes('text-main-white'), 'text-main-white を含まない')
+})
+
+test('Tags: デフォルトタグは teal 系の淡色地になる', () => {
+  // Given/When: `ブログ`/`短編小説` 以外のタグを描画する
+  const html = renderTags(['React'])
+  // Then: デフォルトは teal 淡色地（bg-teal-50）が付く
+  assert.ok(html.includes('bg-teal-50'), 'bg-teal-50 を含む')
+})
+
+test('Tags: パディングを Chip と同一の px-3 py-1 に統一する', () => {
+  // Given/When: 技術タグを描画する
+  const html = renderTags(['React'])
+  // Then: Chip と同じ px-3 py-1（Issue #225 完了条件のパディング統一）
+  assert.ok(html.includes('px-3'), 'px-3 を含む')
+  assert.ok(html.includes('py-1'), 'py-1 を含む')
+  // Then: Chip と食い違う旧値（px-2.5 / py-1.5）を残さない
+  assert.ok(!html.includes('px-2.5'), 'px-2.5 を含まない')
+  assert.ok(!html.includes('py-1.5'), 'py-1.5 を含まない')
+})
+
+test('Tags: `ブログ` は orange 系の色になる（デフォルトと分岐する）', () => {
+  // Given/When: 特別扱いする `ブログ` タグを描画する
+  const html = renderTags(['ブログ'])
+  // Then: orange 系トークンが付き、teal デフォルトにはならない
+  assert.ok(html.includes('orange'), 'orange 系トークンを含む')
+  assert.ok(
+    !html.includes('bg-teal-50'),
+    'デフォルトの bg-teal-50 にはならない',
+  )
+})
+
+test('Tags: `短編小説` も `ブログ` と同じ orange 系分岐になる', () => {
+  // Given/When: 特別扱いする `短編小説` タグを描画する
+  const html = renderTags(['短編小説'])
+  // Then: orange 系トークンが付く
+  assert.ok(html.includes('orange'), 'orange 系トークンを含む')
+})

--- a/src/app/components/molecules/Tags.tsx
+++ b/src/app/components/molecules/Tags.tsx
@@ -7,6 +7,20 @@ interface TagsProps {
   tags: string[]
 }
 
+const TAG_BASE_CLASS =
+  'inline-block cursor-pointer rounded-full px-3 py-1 text-xs font-semibold'
+
+// タグ種別ごとの淡色地＋濃色文字トークン。ここに無いタグは DEFAULT_TAG_COLOR。
+const TAG_COLOR_CLASSES: Record<string, string> = {
+  ブログ:
+    'bg-orange/10 text-orange dark:bg-night-orange/20 dark:text-night-orange',
+  短編小説:
+    'bg-orange/10 text-orange dark:bg-night-orange/20 dark:text-night-orange',
+}
+
+const DEFAULT_TAG_COLOR =
+  'bg-teal-50 text-teal-700 dark:bg-night-teal/20 dark:text-night-teal'
+
 const Tags: React.FC<TagsProps> = ({ tags }) => {
   const router = useRouter()
 
@@ -19,11 +33,7 @@ const Tags: React.FC<TagsProps> = ({ tags }) => {
       {tags.map((tag: string, index: number) => (
         <span
           key={index}
-          className={`inline-block cursor-pointer rounded px-2.5 py-1.5 text-xxs text-main-white md:text-xs ${
-            tag === 'ブログ' || tag === '短編小説'
-              ? 'bg-orange dark:bg-night-orange'
-              : 'bg-teal dark:bg-night-teal'
-          }`}
+          className={`${TAG_BASE_CLASS} ${TAG_COLOR_CLASSES[tag] ?? DEFAULT_TAG_COLOR}`}
           onClick={() => handleClickTag(tag)}
         >
           {tag}

--- a/src/app/components/molecules/TextArrowLinkButton.style.test.tsx
+++ b/src/app/components/molecules/TextArrowLinkButton.style.test.tsx
@@ -1,0 +1,61 @@
+// TextArrowLinkButton の hover 反応を軽量化する className 契約を固定する単体テスト
+// （Issue #225 UI刷新 3/3 / TDD 先行）。
+//
+// #225 は円枠矢印ボタンの hover 塗り反転（group-hover:bg-main-white 等）を撤去し、
+// テキストに下線（group-hover:underline）＋矢印がわずかに右へ動く
+// （group-hover:translate-x-）軽量な反応へ置き換える。
+//
+// TextArrowLinkButton は next.config.mjs と FontAwesome に依存するが、いずれも
+// SSR 描画で問題なく解決される。CSS Module も next/navigation も import しないため
+// 追加の resolve フックは不要。classic JSX runtime のため React をグローバルに渡す。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は塗り反転のままのため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+;(globalThis as Record<string, unknown>).React = React
+
+let TextArrowLinkButton: React.FC<{ text: string; href: string }>
+before(async () => {
+  TextArrowLinkButton = (await import('./TextArrowLinkButton'))
+    .default as unknown as React.FC<{ text: string; href: string }>
+})
+
+const render = (): string =>
+  renderToStaticMarkup(
+    <TextArrowLinkButton text="もっと見る" href="/profile" />,
+  )
+
+test('TextArrowLinkButton: hover の塗り反転（group-hover:bg-main-white）を撤去する', () => {
+  // Given/When: 矢印リンクボタンを描画する
+  const html = render()
+  // Then: 円枠を白で塗り潰す全反転 hover は含まない
+  assert.ok(
+    !html.includes('group-hover:bg-main-white'),
+    'group-hover:bg-main-white を含まない',
+  )
+})
+
+test('TextArrowLinkButton: hover でテキストに下線を付ける', () => {
+  // Given/When: 矢印リンクボタンを描画する
+  const html = render()
+  // Then: ホバー時にテキストへ下線が付く
+  assert.ok(
+    html.includes('group-hover:underline'),
+    'group-hover:underline を含む',
+  )
+})
+
+test('TextArrowLinkButton: hover で矢印がわずかに右へ動く', () => {
+  // Given/When: 矢印リンクボタンを描画する
+  const html = render()
+  // Then: ホバー時に矢印が右方向へ移動する
+  assert.match(
+    html,
+    /group-hover:translate-x-/,
+    'group-hover:translate-x- を含む',
+  )
+})

--- a/src/app/components/molecules/TextArrowLinkButton.tsx
+++ b/src/app/components/molecules/TextArrowLinkButton.tsx
@@ -16,31 +16,28 @@ const TextArrowLinkButton: React.FC<TextArrowLinkButtonProps> = ({
   href,
 }) => {
   return (
-    <>
-      <a
-        href={`${BASE_PATH}${href}`}
-        className="group mt-6 flex select-none items-center"
-      >
-        <h3>{text}</h3>
+    <a
+      href={`${BASE_PATH}${href}`}
+      className="group mt-6 flex select-none items-center"
+    >
+      <h3 className="group-hover:underline">{text}</h3>
 
-        {/* テキストの右につける矢印 */}
-        <button
-          className="
-            relative ml-5 size-8
-            max-h-[32px] max-w-[32px]
-            rounded-full border
-            border-main-black border-opacity-20
-            align-middle text-xs text-main-black transition-all group-hover:bg-main-white
-            group-hover:text-main-black dark:border-main-white dark:text-main-white
-            dark:group-hover:bg-night-white"
-          type="button"
-        >
-          <span>
-            <FontAwesomeIcon icon={faArrowRight} />
-          </span>
-        </button>
-      </a>
-    </>
+      {/* テキストの右につける矢印 */}
+      <button
+        className="
+          relative ml-5 size-8
+          max-h-[32px] max-w-[32px]
+          rounded-full border
+          border-main-black border-opacity-20
+          align-middle text-xs text-main-black
+          dark:border-main-white dark:text-main-white"
+        type="button"
+      >
+        <span className="inline-block transition-transform duration-300 group-hover:translate-x-1">
+          <FontAwesomeIcon icon={faArrowRight} />
+        </span>
+      </button>
+    </a>
   )
 }
 

--- a/src/app/components/templates/Footer.style.test.tsx
+++ b/src/app/components/templates/Footer.style.test.tsx
@@ -1,0 +1,100 @@
+// Footer の細部刷新（絵文字国旗廃止・text-xxs → text-xs 可読性改善）の契約を
+// 固定する単体テスト（Issue #225 UI刷新 3/3 / TDD 先行）。
+//
+// #225 はプラットフォームで表示が割れる絵文字国旗 🇯🇵 / 🇵🇭 を廃止し、都市区切りの
+// faPlane アイコンのサイズを text-xxs → text-xs へ 1 段上げる。本テストは
+// レンダリング結果の観測可能な契約（国旗絵文字が残っていない／Footer 内に text-xxs が
+// 残っていない）を固定する。
+//
+// Footer は useI18n（@/i18n）に依存するため、既存 Header.stagger.test.tsx と同様に
+// 実際の I18nProvider でラップする。renderToStaticMarkup は useEffect を実行しないため
+// ロケールは defaultLocale（ja）のまま。next/link と、内部の AnimatedLine が使う
+// next/navigation(usePathname) は resolve フックでモックへ張り替える。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は国旗絵文字・text-xxs のままのため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+const linkMock =
+  'data:text/javascript,' +
+  encodeURIComponent(
+    "export default function Link(props){return React.createElement('a',{href:props.href,className:props.className,target:props.target,rel:props.rel},props.children)}",
+  )
+
+const navMock =
+  'data:text/javascript,' +
+  encodeURIComponent("export function usePathname(){return '/'}")
+
+const resolveHook = `
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.endsWith('.css')) {
+    return { url: 'data:text/javascript,export default {}', shortCircuit: true }
+  }
+  if (specifier === 'next/link') {
+    return { url: ${JSON.stringify(linkMock)}, shortCircuit: true }
+  }
+  if (specifier === 'next/navigation') {
+    return { url: ${JSON.stringify(navMock)}, shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}
+`
+register(
+  'data:text/javascript,' + encodeURIComponent(resolveHook),
+  import.meta.url,
+)
+;(globalThis as Record<string, unknown>).React = React
+
+let Footer: React.FC
+let I18nProvider: React.FC<{ children: React.ReactNode }>
+before(async () => {
+  Footer = (await import('./Footer')).default as unknown as React.FC
+  I18nProvider = (await import('../../../i18n/context'))
+    .I18nProvider as unknown as React.FC<{ children: React.ReactNode }>
+})
+
+const render = (): string =>
+  renderToStaticMarkup(
+    <I18nProvider>
+      <Footer />
+    </I18nProvider>,
+  )
+
+test('Footer: 例外なく描画される', () => {
+  // Given/When/Then: 刷新後も SSR 描画で throw しない
+  assert.doesNotThrow(() => render())
+})
+
+test('Footer: 日本国旗の絵文字 🇯🇵 を廃止する', () => {
+  // Given/When: フッターを描画する
+  const html = render()
+  // Then: プラットフォーム依存の絵文字国旗が残っていない
+  assert.ok(!html.includes('🇯🇵'), '🇯🇵 を含まない')
+})
+
+test('Footer: フィリピン国旗の絵文字 🇵🇭 を廃止する', () => {
+  // Given/When: フッターを描画する
+  const html = render()
+  // Then: プラットフォーム依存の絵文字国旗が残っていない
+  assert.ok(!html.includes('🇵🇭'), '🇵🇭 を含まない')
+})
+
+test('Footer: 極小フォント text-xxs を text-xs へ上げる', () => {
+  // Given/When: フッターを描画する
+  const html = render()
+  // Then: 可読性改善のため text-xxs は残っていない
+  assert.ok(!html.includes('text-xxs'), 'text-xxs を含まない')
+})
+
+test('Footer: 都市名（ja ロケール）が描画される', () => {
+  // Given/When: defaultLocale(ja) でフッターを描画する
+  const html = render()
+  // Then: 都市の区切り表示は維持され、都市名が出力される
+  assert.ok(html.includes('沖縄'), '沖縄 を含む')
+  assert.ok(html.includes('バコロド'), 'バコロド を含む')
+})

--- a/src/app/components/templates/Footer.tsx
+++ b/src/app/components/templates/Footer.tsx
@@ -21,23 +21,21 @@ export default function Footer() {
               <div className="rightFooter w-full select-none md:w-3/4">
                 <p className="mb-1 text-lg md:mb-3">Motoshi Furugen</p>
                 <p className="flex items-center">
-                  <span className="mr-1">🇯🇵</span>
                   {t.footer.cities.oka}
                   <FontAwesomeIcon
                     icon={faPlane}
-                    className="mx-1 text-xxs opacity-70"
+                    className="mx-1 text-xs opacity-70"
                   />
                   {t.footer.cities.hij}
                   <FontAwesomeIcon
                     icon={faPlane}
-                    className="mx-1 text-xxs opacity-70"
+                    className="mx-1 text-xs opacity-70"
                   />
                   {t.footer.cities.tyo}
                   <FontAwesomeIcon
                     icon={faPlane}
-                    className="mx-1 text-xxs opacity-70"
+                    className="mx-1 text-xs opacity-70"
                   />
-                  <span className="mr-1">🇵🇭</span>
                   {t.footer.cities.bcd}
                 </p>
               </div>


### PR DESCRIPTION
## 概要
GitHub Issue #225「UI刷新(3/3): 細部刷新（ボタン・フッター・タグ/チップ）」を takt（default workflow: テスト先行）で実装。

## 背景

UI/UX刷新の仕上げ。ボタン・フッター・タグ類の細部に残る「一昔前」要素を更新する。**レイアウト構造は変えない。**

前提: デザイントークン刷新＋トップページ刷新のイシューがマージ済みであること。新トークン（teal/orange 新トーン、shadow-card、rounded-lg 統一）に合わせること。

## 変更内容

### 1. ボタン刷新
- `src/app/components/atoms/SubmitButton.tsx`: `shadow-[inset_0_0_0_2px_#4A4A4A]` の inset 影による擬似ボーダー → 通常の `border-2` または塗りボタンへ。`uppercase tracking-widest` を緩和（tracking-wide 程度）。`px-20`/`px-32` 等の過大パディングを `px-10` 前後へ縮小。hover は全反転でなく色の深化＋軽い浮き上がりに
- `src/app/components/atoms/TextArrowLinkButton.tsx`: 細線丸枠＋hover塗り反転の矢印円ボタン → hover でテキスト下線＋矢印がわずかに右へ動く軽量な反応に（円枠を残す場合も反応は控えめに）

### 2. フッター（`src/app/components/templates/Footer.tsx`）
- 絵文字国旗 `🇯🇵`/`🇵🇭` を廃止（プラットフォームで表示が割れる）。都市の区切りはドット `・` またはスラッシュ＋一貫した線アイコンに
- `text-xxs`（0.625rem）を `text-xs` へ1段上げて可読性改善
- faPlane アイコンを使い続ける場合はサイズを text-xs に揃える

### 3. タグ/チップのトークン化
- `src/app/components/atoms/Tags.tsx`: `tag === 'ブログ' || tag === '短編小説'` の日本語文字列ハードコードによる色分岐をマップ（Record<string, クラス>＋デフォルト）に整理。見た目は `rounded-full` 淡色地＋濃色文字へ
- `src/app/components/atoms/Chip.tsx`: Tags と角丸・パディング・フォントサイズを統一

## 完了条件
- `npm run build` 成功、`npm run lint` パス
- contact ページの送信ボタン、ブログカードのタグ、フッターがライト/ダーク両方で自然に見える
- 国旗絵文字が残っていない

---
Workflow `default` completed successfully.

Closes #225

🤖 Generated with takt + Claude Code