### PR TITLE
[#227] UI刷新(5): モバイルメニューを半透明ブラー背景＋タイミング統一に刷新

### DIFF
--- a/src/app/components/molecules/GithubLinkButton.menu.test.tsx
+++ b/src/app/components/molecules/GithubLinkButton.menu.test.tsx
@@ -1,0 +1,132 @@
+// GitHub リンクボタン（src/app/components/molecules/GithubLinkButton.tsx）の
+// モバイルメニュー内での可視制御契約を固定する単体テスト（Issue #227 UI刷新 5 / TDD 先行）。
+//
+// #227 はメニュー項目を open トリガの CSS transition（stagger）で毎回再生する。
+// ヘッダー最後尾の GithubLinkButton も他項目と同じ可視契約を持つ:
+//   - モバイル既定 opacity-0 / open で opacity-100
+//   - 開く時だけ stagger（transition-delay に --stagger-delay）
+//   - md:opacity-100（デスクトップ回帰防止）
+//   - md:animate-fade-in-up（1s keyframe は md 限定）／モバイルでは単独 keyframe 未使用
+//   - motion-reduce:transition-none（reduced-motion で即表示）
+// 加えて Repository ラベルなど既存の表示内容は変えない。本テストはこれらを固定する。
+//
+// GithubLinkButton は next/link と FontAwesome に依存する。next/link は素の <a> へ
+// 差し替える（FontAwesome はモック不要）。
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は該当クラスが無いため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+const linkMock =
+  'data:text/javascript,' +
+  encodeURIComponent(
+    "export default function Link(props){return React.createElement('a',{href:props.href,className:props.className,style:props.style,target:props.target,rel:props.rel},props.children)}",
+  )
+
+const resolveHook = `
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.endsWith('.css')) {
+    return { url: 'data:text/javascript,export default {}', shortCircuit: true }
+  }
+  if (specifier === 'next/link') {
+    return { url: ${JSON.stringify(linkMock)}, shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}
+`
+register(
+  'data:text/javascript,' + encodeURIComponent(resolveHook),
+  import.meta.url,
+)
+
+// tsx は classic JSX runtime へ変換するため React をグローバルに渡す。
+;(globalThis as Record<string, unknown>).React = React
+
+type GithubLinkButtonComponent = React.FC<{ index: number }>
+
+let GithubLinkButton: GithubLinkButtonComponent
+before(async () => {
+  GithubLinkButton = (await import('./GithubLinkButton'))
+    .default as unknown as GithubLinkButtonComponent
+})
+
+const render = (index: number): string =>
+  renderToStaticMarkup(<GithubLinkButton index={index} />)
+
+test('GithubLinkButton: モバイルでは既定 opacity-0（閉時は不可視）', () => {
+  // Given/When: 描画する
+  const html = render(5)
+  // Then: 閉じている間は隠れている
+  assert.ok(html.includes('opacity-0'), 'opacity-0 を含む')
+})
+
+test('GithubLinkButton: open トリガで opacity-100 へフェードインする', () => {
+  // Given/When: 描画する
+  const html = render(5)
+  // Then: nav の open 状態に反応して表示される
+  assert.ok(
+    html.includes('group-data-[open=true]:opacity-100'),
+    'group-data-[open=true]:opacity-100 を含む',
+  )
+})
+
+test('GithubLinkButton: 開く時だけ stagger する（transition-delay に --stagger-delay）', () => {
+  // Given/When: 描画する
+  const html = render(5)
+  // Then: 遅延は open variant にのみ付く
+  assert.ok(
+    html.includes(
+      'group-data-[open=true]:[transition-delay:var(--stagger-delay)]',
+    ),
+    'group-data-[open=true]:[transition-delay:var(--stagger-delay)] を含む',
+  )
+})
+
+test('GithubLinkButton: md 以上では常時可視（md:opacity-100）', () => {
+  // Given/When: 描画する
+  const html = render(5)
+  // Then: デスクトップでは隠れない
+  assert.ok(html.includes('md:opacity-100'), 'md:opacity-100 を含む')
+})
+
+test('GithubLinkButton: 1s keyframe はデスクトップ限定（md:animate-fade-in-up）', () => {
+  // Given/When: 描画する
+  const html = render(5)
+  // Then: mount フェードは md 限定で温存する
+  assert.ok(
+    html.includes('md:animate-fade-in-up'),
+    'md:animate-fade-in-up を含む',
+  )
+})
+
+test('GithubLinkButton: モバイルでは単独 animate-fade-in-up を使わない', () => {
+  // Given/When: 描画する
+  const html = render(5)
+  // Then: md: を伴わない単独の keyframe クラスは付かない
+  assert.doesNotMatch(
+    html,
+    /(^|[\s"'])animate-fade-in-up/,
+    '単独の animate-fade-in-up を含まない（md: 限定のみ）',
+  )
+})
+
+test('GithubLinkButton: reduced-motion では transition を無効化する', () => {
+  // Given/When: 描画する
+  const html = render(5)
+  // Then: prefers-reduced-motion で即表示
+  assert.ok(
+    html.includes('motion-reduce:transition-none'),
+    'motion-reduce:transition-none を含む',
+  )
+})
+
+test('GithubLinkButton: Repository ラベルは維持する', () => {
+  // Given/When: 描画する
+  const html = render(5)
+  // Then: 既存の表示内容は変えない
+  assert.ok(html.includes('Repository'), 'Repository を含む')
+})

--- a/src/app/components/molecules/GithubLinkButton.tsx
+++ b/src/app/components/molecules/GithubLinkButton.tsx
@@ -2,6 +2,7 @@ import { faGithub } from '@fortawesome/free-brands-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Link from 'next/link'
 import React from 'react'
+import { headerMenuItemMotionClass } from './headerMenuItemMotion'
 import { staggerStyle } from './staggerStyle'
 
 interface GithubLinkButtonProps {
@@ -11,7 +12,7 @@ interface GithubLinkButtonProps {
 const GithubLinkButton: React.FC<GithubLinkButtonProps> = ({ index }) => {
   return (
     <Link
-      className="mr-auto mt-8 animate-fade-in-up motion-reduce:animate-none md:mt-0"
+      className={`mr-auto mt-8 md:mt-0 ${headerMenuItemMotionClass}`}
       style={staggerStyle(index)}
       href="https://github.com/motoshifurugen/my_site"
       target="_blank"

--- a/src/app/components/molecules/HeaderDropdownButton.menu.test.tsx
+++ b/src/app/components/molecules/HeaderDropdownButton.menu.test.tsx
@@ -1,0 +1,135 @@
+// ヘッダードロップダウン（src/app/components/molecules/HeaderDropdownButton.tsx）の
+// モバイルメニュー内での可視制御契約を固定する単体テスト（Issue #227 UI刷新 5 / TDD 先行）。
+//
+// #227 は各メニュー項目を open トリガの CSS transition（stagger）で毎回再生する。
+// ドロップダウンのラッパ <div>（stagger の起点）も HeaderLinkButton と同じ可視契約を持つ:
+//   - モバイル既定 opacity-0 / open で opacity-100
+//   - 開く時だけ stagger（transition-delay に --stagger-delay）
+//   - md:opacity-100（デスクトップ回帰防止）
+//   - md:animate-fade-in-up（1s keyframe は md 限定）／モバイルでは単独 keyframe 未使用
+//   - motion-reduce:transition-none（reduced-motion で即表示）
+// 本テストはこのクラス契約を固定する。
+//
+// HeaderDropdownButton は next/link と FontAwesome に依存する。FontAwesome は SSR で
+// SVG を描画するためモック不要。next/link は素の <a> へ差し替える。
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は該当クラスが無いため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+const linkMock =
+  'data:text/javascript,' +
+  encodeURIComponent(
+    "export default function Link(props){return React.createElement('a',{href:props.href,className:props.className,style:props.style},props.children)}",
+  )
+
+const resolveHook = `
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.endsWith('.css')) {
+    return { url: 'data:text/javascript,export default {}', shortCircuit: true }
+  }
+  if (specifier === 'next/link') {
+    return { url: ${JSON.stringify(linkMock)}, shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}
+`
+register(
+  'data:text/javascript,' + encodeURIComponent(resolveHook),
+  import.meta.url,
+)
+
+// tsx は classic JSX runtime へ変換するため React をグローバルに渡す。
+;(globalThis as Record<string, unknown>).React = React
+
+type HeaderDropdownButtonComponent = React.FC<{
+  text: string
+  subItems: { href: string; text: string }[]
+  index: number
+}>
+
+let HeaderDropdownButton: HeaderDropdownButtonComponent
+before(async () => {
+  HeaderDropdownButton = (await import('./HeaderDropdownButton'))
+    .default as unknown as HeaderDropdownButtonComponent
+})
+
+const render = (index: number): string =>
+  renderToStaticMarkup(
+    <HeaderDropdownButton
+      text="遊び"
+      subItems={[{ href: '/game', text: 'ゲーム' }]}
+      index={index}
+    />,
+  )
+
+test('HeaderDropdownButton: モバイルでは既定 opacity-0（閉時は不可視）', () => {
+  // Given/When: 描画する
+  const html = render(4)
+  // Then: 閉じている間は隠れている
+  assert.ok(html.includes('opacity-0'), 'opacity-0 を含む')
+})
+
+test('HeaderDropdownButton: open トリガで opacity-100 へフェードインする', () => {
+  // Given/When: 描画する
+  const html = render(4)
+  // Then: nav の open 状態に反応して表示される
+  assert.ok(
+    html.includes('group-data-[open=true]:opacity-100'),
+    'group-data-[open=true]:opacity-100 を含む',
+  )
+})
+
+test('HeaderDropdownButton: 開く時だけ stagger する（transition-delay に --stagger-delay）', () => {
+  // Given/When: 描画する
+  const html = render(4)
+  // Then: 遅延は open variant にのみ付く
+  assert.ok(
+    html.includes(
+      'group-data-[open=true]:[transition-delay:var(--stagger-delay)]',
+    ),
+    'group-data-[open=true]:[transition-delay:var(--stagger-delay)] を含む',
+  )
+})
+
+test('HeaderDropdownButton: md 以上では常時可視（md:opacity-100）', () => {
+  // Given/When: 描画する
+  const html = render(4)
+  // Then: デスクトップでは隠れない
+  assert.ok(html.includes('md:opacity-100'), 'md:opacity-100 を含む')
+})
+
+test('HeaderDropdownButton: 1s keyframe はデスクトップ限定（md:animate-fade-in-up）', () => {
+  // Given/When: 描画する
+  const html = render(4)
+  // Then: mount フェードは md 限定で温存する
+  assert.ok(
+    html.includes('md:animate-fade-in-up'),
+    'md:animate-fade-in-up を含む',
+  )
+})
+
+test('HeaderDropdownButton: モバイルでは単独 animate-fade-in-up を使わない', () => {
+  // Given/When: 描画する
+  const html = render(4)
+  // Then: md: を伴わない単独の keyframe クラスは付かない
+  assert.doesNotMatch(
+    html,
+    /(^|[\s"'])animate-fade-in-up/,
+    '単独の animate-fade-in-up を含まない（md: 限定のみ）',
+  )
+})
+
+test('HeaderDropdownButton: reduced-motion では transition を無効化する', () => {
+  // Given/When: 描画する
+  const html = render(4)
+  // Then: prefers-reduced-motion で即表示
+  assert.ok(
+    html.includes('motion-reduce:transition-none'),
+    'motion-reduce:transition-none を含む',
+  )
+})

--- a/src/app/components/molecules/HeaderDropdownButton.tsx
+++ b/src/app/components/molecules/HeaderDropdownButton.tsx
@@ -4,6 +4,7 @@ import { faChevronDown } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Link from 'next/link'
 import React, { useState } from 'react'
+import { headerMenuItemMotionClass } from './headerMenuItemMotion'
 import { staggerStyle } from './staggerStyle'
 
 interface SubMenuItem {
@@ -26,17 +27,17 @@ const HeaderDropdownButton: React.FC<HeaderDropdownButtonProps> = ({
 
   return (
     <div
-      className="mt-6 flex animate-fade-in-up items-center pr-8 motion-reduce:animate-none md:mr-10 md:mt-0 md:pr-0"
+      className={`mt-6 flex items-center pr-8 md:mr-10 md:mt-0 md:pr-0 ${headerMenuItemMotionClass}`}
       style={staggerStyle(index)}
     >
       <div
-        className="relative inline-block ml-auto md:ml-0 cursor-pointer"
+        className="relative ml-auto inline-block cursor-pointer md:ml-0"
         onMouseEnter={() => window.innerWidth >= 768 && setIsOpen(true)}
         onMouseLeave={() => window.innerWidth >= 768 && setIsOpen(false)}
       >
         <button
           onClick={() => setIsOpen(!isOpen)}
-          className="flex items-center cursor-pointer"
+          className="flex cursor-pointer items-center"
         >
           <span className="noto-sans-jp select-none text-lg font-bold text-main-black dark:text-night-white md:text-base">
             {text}
@@ -54,7 +55,7 @@ const HeaderDropdownButton: React.FC<HeaderDropdownButtonProps> = ({
                 <Link
                   key={subIndex}
                   href={item.href}
-                  className="block w-full px-4 py-3 text-right md:text-center text-base font-bold text-black dark:text-night-white hover:bg-gray-100 dark:hover:bg-night-gray"
+                  className="hover:bg-gray-100 block w-full px-4 py-3 text-right text-base font-bold text-black dark:text-night-white dark:hover:bg-night-gray md:text-center"
                   onClick={() => setIsOpen(false)}
                 >
                   {item.text}

--- a/src/app/components/molecules/HeaderLinkButton.menu.test.tsx
+++ b/src/app/components/molecules/HeaderLinkButton.menu.test.tsx
@@ -1,0 +1,134 @@
+// ヘッダーリンク（src/app/components/molecules/HeaderLinkButton.tsx）の
+// モバイルメニュー内での可視制御契約を固定する単体テスト（Issue #227 UI刷新 5 / TDD 先行）。
+//
+// #227 はモバイルメニューの項目を、mount 時のみ発火する 1s keyframe（animate-fade-in-up）
+// ではなく、open をトリガーにした軽い CSS transition（stagger）で毎回再生する。
+// そのため各項目のルート要素は:
+//   - モバイルでは既定 opacity-0（閉時は不可視）
+//   - open（nav の group-data-[open=true]）で opacity-100 へフェードイン
+//   - 開く時だけ stagger する（transition-delay に --stagger-delay を使う）
+//   - md 以上では常時可視（md:opacity-100）で #224 のデスクトップ挙動を回帰させない
+//   - 1s keyframe はデスクトップ限定（md:animate-fade-in-up）にし、モバイルでは使わない
+//   - prefers-reduced-motion では transition を無効化（motion-reduce:transition-none）
+// を満たす className を持つ。本テストはこのクラス契約を固定する。
+//
+// renderToStaticMarkup は SSR 静的 HTML（jsdom 無し・状態トグル不可）のため、
+// 開閉の実挙動ではなく className の存在で契約をロックする（#224 style.test と同方針）。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は該当クラスが無いため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+const linkMock =
+  'data:text/javascript,' +
+  encodeURIComponent(
+    "export default function Link(props){return React.createElement('a',{href:props.href,className:props.className,style:props.style,target:props.target,rel:props.rel},props.children)}",
+  )
+
+const resolveHook = `
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.endsWith('.css')) {
+    return { url: 'data:text/javascript,export default {}', shortCircuit: true }
+  }
+  if (specifier === 'next/link') {
+    return { url: ${JSON.stringify(linkMock)}, shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}
+`
+register(
+  'data:text/javascript,' + encodeURIComponent(resolveHook),
+  import.meta.url,
+)
+
+// tsx は classic JSX runtime へ変換するため React をグローバルに渡す。
+;(globalThis as Record<string, unknown>).React = React
+
+type HeaderLinkButtonComponent = React.FC<{
+  href: string
+  text: string
+  index: number
+}>
+
+let HeaderLinkButton: HeaderLinkButtonComponent
+before(async () => {
+  HeaderLinkButton = (await import('./HeaderLinkButton'))
+    .default as unknown as HeaderLinkButtonComponent
+})
+
+const render = (index: number): string =>
+  renderToStaticMarkup(
+    <HeaderLinkButton href="/blog" text="ブログ" index={index} />,
+  )
+
+test('HeaderLinkButton: モバイルでは既定 opacity-0（閉時は不可視）', () => {
+  // Given/When: 描画する
+  const html = render(1)
+  // Then: 閉じている間は隠れている
+  assert.ok(html.includes('opacity-0'), 'opacity-0 を含む')
+})
+
+test('HeaderLinkButton: open トリガ（group-data-[open=true]）で opacity-100 へフェードインする', () => {
+  // Given/When: 描画する
+  const html = render(1)
+  // Then: nav の open 状態に反応して表示される
+  assert.ok(
+    html.includes('group-data-[open=true]:opacity-100'),
+    'group-data-[open=true]:opacity-100 を含む',
+  )
+})
+
+test('HeaderLinkButton: 開く時だけ stagger する（transition-delay に --stagger-delay を使う）', () => {
+  // Given/When: 描画する
+  const html = render(1)
+  // Then: 遅延は open variant にのみ付き、閉じる時は同時フェードアウトになる
+  assert.ok(
+    html.includes(
+      'group-data-[open=true]:[transition-delay:var(--stagger-delay)]',
+    ),
+    'group-data-[open=true]:[transition-delay:var(--stagger-delay)] を含む',
+  )
+})
+
+test('HeaderLinkButton: md 以上では常時可視（md:opacity-100）でデスクトップ挙動を回帰させない', () => {
+  // Given/When: 描画する
+  const html = render(1)
+  // Then: デスクトップ水平ヘッダーは opacity-0 に隠れない
+  assert.ok(html.includes('md:opacity-100'), 'md:opacity-100 を含む')
+})
+
+test('HeaderLinkButton: 1s keyframe はデスクトップ限定（md:animate-fade-in-up）にする', () => {
+  // Given/When: 描画する
+  const html = render(1)
+  // Then: #224 のデスクトップ mount フェードは md 限定で温存する
+  assert.ok(
+    html.includes('md:animate-fade-in-up'),
+    'md:animate-fade-in-up を含む',
+  )
+})
+
+test('HeaderLinkButton: モバイルでは 1s keyframe（単独 animate-fade-in-up）を使わない', () => {
+  // Given/When: 描画する
+  const html = render(1)
+  // Then: md: を伴わない単独の animate-fade-in-up は付かない（メニュー内では未使用）
+  assert.doesNotMatch(
+    html,
+    /(^|[\s"'])animate-fade-in-up/,
+    '単独の animate-fade-in-up を含まない（md: 限定のみ）',
+  )
+})
+
+test('HeaderLinkButton: reduced-motion では transition を無効化する', () => {
+  // Given/When: 描画する
+  const html = render(1)
+  // Then: prefers-reduced-motion で即表示（transition なし）
+  assert.ok(
+    html.includes('motion-reduce:transition-none'),
+    'motion-reduce:transition-none を含む',
+  )
+})

--- a/src/app/components/molecules/HeaderLinkButton.tsx
+++ b/src/app/components/molecules/HeaderLinkButton.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import React from 'react'
+import { headerMenuItemMotionClass } from './headerMenuItemMotion'
 import { staggerStyle } from './staggerStyle'
 
 interface HeaderLinkButtonProps {
@@ -15,7 +16,7 @@ const HeaderLinkButton: React.FC<HeaderLinkButtonProps> = ({
 }) => {
   return (
     <Link
-      className="mt-6 flex animate-fade-in-up items-center pr-8 hover:opacity-50 motion-reduce:animate-none md:mr-10 md:mt-0 md:pr-0"
+      className={`mt-6 flex items-center pr-8 hover:opacity-50 md:mr-10 md:mt-0 md:pr-0 ${headerMenuItemMotionClass}`}
       style={staggerStyle(index)}
       href={href}
     >

--- a/src/app/components/molecules/headerMenuItemMotion.ts
+++ b/src/app/components/molecules/headerMenuItemMotion.ts
@@ -1,0 +1,15 @@
+// モバイルメニュー内の各項目（HeaderLinkButton / HeaderDropdownButton /
+// GithubLinkButton）が共有する可視制御・モーション契約クラス（Issue #227）。
+//
+// - モバイル: 既定 opacity-0（閉時は不可視）。nav の open（group-data-[open=true]）で
+//   opacity-100 へ opacity フェードし、開く時だけ --stagger-delay 分だけ遅らせて stagger。
+//   閉じる時は遅延なしで同時にフェードアウトする。
+// - md（デスクトップ）: 常時可視（md:opacity-100）で #224 の水平ヘッダー挙動を回帰させない。
+//   mount 時の 1s keyframe（fadeInUp）は md 限定（md:animate-fade-in-up）で温存する。
+//   opacity フェードの transition は max-md 限定にして、デスクトップの hover:opacity-50 を
+//   即時のまま保つ（transition を md まで及ぼさない）。
+// - prefers-reduced-motion: transition / keyframe とも無効化し即表示/即非表示。
+//
+// この文字列がメニュー項目の可視契約の単一の情報源。3 コンポーネントで共有する。
+export const headerMenuItemMotionClass =
+  'opacity-0 max-md:transition-opacity max-md:duration-200 max-md:ease-out group-data-[open=true]:opacity-100 group-data-[open=true]:[transition-delay:var(--stagger-delay)] motion-reduce:transition-none motion-reduce:animate-none md:animate-fade-in-up md:opacity-100'

--- a/src/app/components/molecules/staggerStyle.mobile.test.ts
+++ b/src/app/components/molecules/staggerStyle.mobile.test.ts
@@ -1,0 +1,70 @@
+// staggerStyle（src/app/components/molecules/staggerStyle.ts）の
+// モバイルメニュー用 stagger 契約を固定する単体テスト（Issue #227 UI刷新 5 / TDD 先行）。
+//
+// #227 はモバイルメニューの項目を open トリガの CSS transition で段階表示する。
+// この stagger 間隔は 1s keyframe（#224 の animationDelay 80ms）とは別系統で、
+// transition-delay に流す CSS 変数 `--stagger-delay`（1項目 50ms 差）を staggerStyle が
+// 単一の情報源として提供する。本テストはその index → --stagger-delay の対応を固定する。
+//
+// #224 由来の animationDelay（80ms）/ animationFillMode（backwards）は md 用として維持
+// されることも併せて固定し、両系統が共存することを保証する。
+//
+// staggerStyle は type-only import のみで CSS を読まないため直接 import できる。
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は --stagger-delay 未提供のため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { staggerStyle } from './staggerStyle'
+
+// CSSProperties にはカスタムプロパティのインデックスが無いため Record で受ける。
+const asRecord = (index: number): Record<string, unknown> =>
+  staggerStyle(index) as unknown as Record<string, unknown>
+
+test('staggerStyle: モバイル用 --stagger-delay を index * 50ms で出力する', () => {
+  // Given: リストの 3 番目（index=2）に配置される
+  // When: スタイルを生成する
+  const style = asRecord(2)
+  // Then: 開く時の stagger 用に 1項目 50ms 差の遅延が付く
+  assert.equal(style['--stagger-delay'], '100ms', 'index=2 → 100ms')
+})
+
+test('staggerStyle: 先頭（index=0）の --stagger-delay は 0ms', () => {
+  // Given: リスト先頭
+  // When: スタイルを生成する
+  const style = asRecord(0)
+  // Then: 先頭は遅延ゼロで開く時も最初に出現する
+  assert.equal(style['--stagger-delay'], '0ms', 'index=0 → 0ms')
+})
+
+test('staggerStyle: 2 番目（index=1）の --stagger-delay は 50ms', () => {
+  // Given: リスト 2 番目
+  // When: スタイルを生成する
+  const style = asRecord(1)
+  // Then: 40〜60ms 範囲の 50ms 差が付く
+  assert.equal(style['--stagger-delay'], '50ms', 'index=1 → 50ms')
+})
+
+test('staggerStyle: md 用の animationDelay（80ms 系）は維持する', () => {
+  // Given: index=2
+  // When: スタイルを生成する
+  const style = staggerStyle(2)
+  // Then: #224 のデスクトップ mount stagger（index * 80ms）は据え置き
+  assert.equal(
+    style.animationDelay,
+    '160ms',
+    'index=2 → 160ms（md keyframe 用）',
+  )
+})
+
+test('staggerStyle: md 用の animationFillMode（backwards）は維持する', () => {
+  // Given: index=1
+  // When: スタイルを生成する
+  const style = staggerStyle(1)
+  // Then: #224 の fill-mode: backwards は据え置き
+  assert.equal(
+    style.animationFillMode,
+    'backwards',
+    'animationFillMode は backwards のまま',
+  )
+})

--- a/src/app/components/molecules/staggerStyle.ts
+++ b/src/app/components/molecules/staggerStyle.ts
@@ -4,10 +4,19 @@ import type { CSSProperties } from 'react'
 // この値がヘッダー stagger 全体の間隔を決める単一の情報源。
 const STAGGER_STEP_MS = 80
 
+// モバイルメニューを open トリガの CSS transition で段階表示する際の遅延ステップ（ms）。
+// 1s keyframe（STAGGER_STEP_MS）とは別系統で、transition-delay に流す
+// CSS 変数 --stagger-delay の間隔を決める単一の情報源（1項目 50ms 差）。
+const MOBILE_STAGGER_STEP_MS = 50
+
 // index に応じた stagger 用インラインスタイルを返す。
-// 遅延中は fadeInUp の 0% 状態を保持するため fill-mode を backwards にする
-// （未指定だと遅延中に一瞬フル表示されてしまう）。
-export const staggerStyle = (index: number): CSSProperties => ({
-  animationDelay: `${index * STAGGER_STEP_MS}ms`,
-  animationFillMode: 'backwards',
-})
+// - md（デスクトップ）用: 1s keyframe を index * 80ms 遅らせて mount 時に段階表示。
+//   遅延中は fadeInUp の 0% 状態を保持するため fill-mode を backwards にする
+//   （未指定だと遅延中に一瞬フル表示されてしまう）。
+// - モバイル用: open トリガの transition-delay に流す --stagger-delay（index * 50ms）。
+export const staggerStyle = (index: number): CSSProperties =>
+  ({
+    animationDelay: `${index * STAGGER_STEP_MS}ms`,
+    animationFillMode: 'backwards',
+    '--stagger-delay': `${index * MOBILE_STAGGER_STEP_MS}ms`,
+  }) as CSSProperties

--- a/src/app/components/templates/Header.menu.test.tsx
+++ b/src/app/components/templates/Header.menu.test.tsx
@@ -1,0 +1,184 @@
+// Header（src/app/components/templates/Header.tsx）のモバイルメニュー刷新の
+// 構造・open 状態配線を固定するインテグレーションテスト（Issue #227 UI刷新 5 / TDD 先行）。
+//
+// #227 はモバイルメニューを「不透明パネルへの全画面置換＋横スライド」から
+// 「半透明＋backdrop-blur の背景＋opacity フェード」に刷新する。要件を SSR 静的 HTML で
+// 検証可能なクラス/属性契約として固定する:
+//   1. 背景の刷新: 専用 backdrop 子が backdrop-blur-md ＋半透明（bg-white/70・dark も）を持ち、
+//      backdrop-filter 非対応向けに @supports フォールバック
+//      （supports-[backdrop-filter]: 側で半透明、非対応時は不透明度を上げる）を持つ
+//   2. 遷移統一: nav は transition-all / translate-x-full（横スライド）を使わず、opacity フェードへ
+//   3. open 状態の配線: nav が group ＋ data-open 属性を持ち、閉時（初期状態）は data-open="false"。
+//      各項目は group-data-[open=true]:opacity-100 で nav の open に反応する（横断データフロー）
+//
+// renderToStaticMarkup は effect 未実行・状態トグル不可のため、
+// body スクロールロック等の副作用挙動は本テストの対象外（クラス/構造の存在で契約をロック）。
+// usePathname はトップページ相当の '/' を返す（初期 menuOpen=false のまま描画）。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は該当クラス/属性が無いため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+const linkMock =
+  'data:text/javascript,' +
+  encodeURIComponent(
+    "export default function Link(props){return React.createElement('a',{href:props.href,className:props.className,style:props.style,target:props.target,rel:props.rel},props.children)}",
+  )
+
+const navMock =
+  'data:text/javascript,' +
+  encodeURIComponent("export function usePathname(){return '/'}")
+
+const resolveHook = `
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.endsWith('.css')) {
+    return { url: 'data:text/javascript,export default {}', shortCircuit: true }
+  }
+  if (specifier === 'next/link') {
+    return { url: ${JSON.stringify(linkMock)}, shortCircuit: true }
+  }
+  if (specifier === 'next/navigation') {
+    return { url: ${JSON.stringify(navMock)}, shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}
+`
+register(
+  'data:text/javascript,' + encodeURIComponent(resolveHook),
+  import.meta.url,
+)
+
+// tsx は classic JSX runtime へ変換するため React をグローバルに渡す。
+;(globalThis as Record<string, unknown>).React = React
+
+let Header: React.FC
+let I18nProvider: React.FC<{ children: React.ReactNode }>
+before(async () => {
+  Header = (await import('./Header')).default as unknown as React.FC
+  I18nProvider = (await import('../../../i18n/context'))
+    .I18nProvider as unknown as React.FC<{ children: React.ReactNode }>
+})
+
+const render = (): string =>
+  renderToStaticMarkup(
+    <I18nProvider>
+      <Header />
+    </I18nProvider>,
+  )
+
+test('Header: 例外なく描画される', () => {
+  // Given/When/Then: メニュー刷新後も SSR 描画で throw しない
+  assert.doesNotThrow(() => render())
+})
+
+// --- 1. 背景の刷新（半透明 + backdrop-blur + @supports フォールバック） ---
+
+test('Header: 背景に backdrop-blur を用いる', () => {
+  // Given/When: ヘッダーを描画する
+  const html = render()
+  // Then: 後ろが透けてぼける専用 backdrop を持つ
+  assert.ok(html.includes('backdrop-blur-md'), 'backdrop-blur-md を含む')
+})
+
+test('Header: backdrop-filter 対応時はライト背景が半透明（bg-white/70）', () => {
+  // Given/When: ヘッダーを描画する
+  const html = render()
+  // Then: @supports 側で半透明にし後ろを透けさせる
+  assert.ok(
+    html.includes('supports-[backdrop-filter]:bg-white/70'),
+    'supports-[backdrop-filter]:bg-white/70 を含む',
+  )
+})
+
+test('Header: backdrop-filter 対応時はダーク背景が半透明（dark:bg-night-black/70）', () => {
+  // Given/When: ヘッダーを描画する
+  const html = render()
+  // Then: ダークでも @supports 側で半透明
+  assert.ok(
+    html.includes('dark:supports-[backdrop-filter]:bg-night-black/70'),
+    'dark:supports-[backdrop-filter]:bg-night-black/70 を含む',
+  )
+})
+
+test('Header: backdrop-filter 非対応向けに不透明度を上げたフォールバック背景を持つ（ライト）', () => {
+  // Given/When: ヘッダーを描画する
+  const html = render()
+  // Then: blur が効かない環境でも可読性を確保する不透明寄りの背景
+  assert.ok(html.includes('bg-white/90'), 'bg-white/90 を含む')
+})
+
+test('Header: backdrop-filter 非対応向けフォールバック背景を持つ（ダーク）', () => {
+  // Given/When: ヘッダーを描画する
+  const html = render()
+  // Then: ダークでも非対応フォールバックを持つ
+  assert.ok(
+    html.includes('dark:bg-night-black/90'),
+    'dark:bg-night-black/90 を含む',
+  )
+})
+
+// --- 2. 遷移タイミングの統一（transition-all / 横スライドの廃止） ---
+
+test('Header: 横スライド（translate-x-full）を使わない', () => {
+  // Given/When: ヘッダーを描画する
+  const html = render()
+  // Then: スライドインは廃止され opacity フェードに統一される
+  assert.ok(!html.includes('translate-x-full'), 'translate-x-full を含まない')
+})
+
+test('Header: transition-all を使わない（opacity フェードへ統一）', () => {
+  // Given/When: ヘッダーを描画する
+  const html = render()
+  // Then: slide+背景色の一括遷移をやめ opacity 一本に統一する
+  assert.ok(!html.includes('transition-all'), 'transition-all を含まない')
+})
+
+// 注: 開時の solid 全画面背景（bg-white dark:bg-night-black）の廃止は要件だが、
+// SSR 静的 HTML は初期 menuOpen=false の閉状態のみを描画し open 分岐が出力されないため、
+// 「solid を使わない」ことは静的マークアップでは判定できない。上記 backdrop 半透明契約と
+// translate-x-full/transition-all の廃止で背景・遷移の刷新を担保する。
+
+// --- 3. open 状態の配線（group + data-open → 各項目の group-data variant） ---
+
+test('Header: nav が open 状態を子へ伝える group を持つ', () => {
+  // Given/When: ヘッダーを描画する
+  const html = render()
+  // Then: 各項目が反応できるよう group クラスを持つ
+  assert.match(html, /<nav[^>]*\bgroup\b/, 'nav に group クラスがある')
+})
+
+test('Header: nav が data-open 属性を持ち、初期（閉）は false', () => {
+  // Given/When: 初期状態（menuOpen=false）で描画する
+  const html = render()
+  // Then: open 状態を data-open 属性で子へ公開し、初期は閉じている
+  assert.match(
+    html,
+    /<nav[^>]*data-open="false"/,
+    'nav に data-open="false" がある',
+  )
+})
+
+test('Header: 各項目が nav の open に反応する（group-data-[open=true] を横断配線）', () => {
+  // Given/When: ヘッダーを描画する
+  const html = render()
+  // Then: nav → 各項目まで open 状態が届き、開時に表示される
+  assert.ok(
+    html.includes('group-data-[open=true]:opacity-100'),
+    'group-data-[open=true]:opacity-100 を含む',
+  )
+})
+
+test('Header: 項目のフェードは reduced-motion で無効化される（motion-reduce:transition-none）', () => {
+  // Given/When: ヘッダーを描画する
+  const html = render()
+  // Then: prefers-reduced-motion で即表示/即非表示
+  assert.ok(
+    html.includes('motion-reduce:transition-none'),
+    'motion-reduce:transition-none を含む',
+  )
+})

--- a/src/app/components/templates/Header.tsx
+++ b/src/app/components/templates/Header.tsx
@@ -44,6 +44,14 @@ const Header = () => {
     setMenuOpen(false)
   }, [pathname])
 
+  // メニューを開いている間は背後のスクロールをロックする
+  useEffect(() => {
+    document.body.style.overflow = menuOpen ? 'hidden' : ''
+    return () => {
+      document.body.style.overflow = ''
+    }
+  }, [menuOpen])
+
   return (
     <header
       className={`
@@ -76,13 +84,27 @@ const Header = () => {
 
         <div className="flex md:ml-auto md:justify-end">
           <nav
+            data-open={menuOpen ? 'true' : 'false'}
             className={`
-            item-left fixed right-0 top-0 flex
-            h-full flex-col flex-wrap transition-all duration-150 ease-in-out md:flex-row
-            ${menuOpen ? 'translate-x-0 bg-white dark:bg-night-black' : 'translate-x-full bg-transparent'} w-full px-4 pt-20
-            md:relative md:translate-x-0 md:bg-transparent md:p-0
+            item-left group fixed right-0 top-0 flex
+            size-full flex-col flex-wrap px-4 pt-20 ease-out md:flex-row
+            ${menuOpen ? 'pointer-events-auto' : 'pointer-events-none'}
+            md:pointer-events-auto md:relative md:bg-transparent md:p-0
           `}
           >
+            {/* 半透明＋backdrop-blur の背景（backdrop-filter 非対応時は不透明度を上げる）。
+                項目・背景ともに open で同時にフェードイン/アウトする。 */}
+            <div
+              aria-hidden="true"
+              className={`
+              absolute inset-0 -z-10 bg-white/90 backdrop-blur-md transition-opacity duration-200
+              ease-out supports-[backdrop-filter]:bg-white/70
+              dark:bg-night-black/90 dark:supports-[backdrop-filter]:bg-night-black/70
+              ${menuOpen ? 'opacity-100' : 'opacity-0'}
+              motion-reduce:transition-none md:hidden
+            `}
+            />
+
             {links.map((link, index) => (
               <HeaderLinkButton
                 key={index}
@@ -99,8 +121,8 @@ const Header = () => {
               index={links.length}
             />
 
-            {/* スマホメニュー内のコントロール群（横並び） */}
-            <div className="mt-6 pr-8 flex items-center justify-end space-x-4 md:hidden">
+            {/* スマホメニュー内のコントロール群（横並び）。項目と同じく open で表示する */}
+            <div className="mt-6 flex items-center justify-end space-x-4 pr-8 opacity-0 transition-opacity duration-200 ease-out group-data-[open=true]:opacity-100 motion-reduce:transition-none md:hidden">
               <ThemeSwitch />
               <LanguageSwitcher />
             </div>


### PR DESCRIPTION
## 概要
GitHub Issue #227「UI刷新(5): モバイルメニューを半透明ブラー背景＋タイミング統一に刷新」を takt（default workflow: テスト先行）で実装。

## 背景

スマホのハンバーガーメニューを開くと、全画面が不透明パネル（light=`bg-white` / dark=`bg-night-black`）でガラッと置き換わり美しくない。さらに `Header.tsx` の nav は `transition-all duration-150`（slide+背景色を一括遷移）なのに、リンク項目は `animate-fade-in-up`（1s・**mount時のみ発火**）のため、パネルと項目のタイミングがずれ、2回目以降の開閉では項目アニメが発火しない。

前提: #223〜#226 マージ済み。

## 変更内容（`src/app/components/templates/Header.tsx` / `HeaderLinkButton.tsx` ほか）

### 1. 背景を「置き換え」から「半透明＋ぼかし」へ
- 開いたときの全画面 solid 背景をやめ、**半透明＋backdrop-blur** に変更（目安: `bg-white/70 dark:bg-night-black/70 backdrop-blur-md`）。後ろのコンテンツは透けつつ、ぼかしで文字の可読性を担保する
- `backdrop-filter` 非対応環境向けに `@supports` フォールバック（不透明度を上げる等）を入れる

### 2. 遷移タイミングの統一
- `transition-all` をやめ、**opacityフェード1本**（150〜250ms・ease-out）に統一。横スライド（`translate-x-full`）は廃止してよい
- リンク項目は `animate-fade-in-up`（1s keyframe）をメニュー内では使わず、**open をトリガーに** 200〜300ms の軽い stagger（1項目 40〜60ms 差）で表示。閉→開のたびに再生されること
- 閉じるときは項目・背景とも同時にフェードアウト（ずれを作らない）

### 3. 挙動の整え
- 開いている間は body スクロールロック
- 既存の「ルート遷移で自動クローズ」は維持
- `prefers-reduced-motion: reduce` ではアニメなしで即表示/即非表示

## 完了条件
- `npm run build` 成功、`npm run lint` パス
- メニュー開時に背景がガラッと変わらず、後ろが透けてぼけて見える（ライト/ダーク両方）
- 開閉を繰り返しても項目のフェードが毎回同じタイミングで再生される
- reduce 設定でアニメーションが無効になる

---
Workflow `default` completed successfully.

Closes #227

🤖 Generated with takt + Claude Code