### PR TITLE
[#228] UI刷新(6): ライトモードのフッターを砂浜テーマに＋コピーライトを Furugen Island へ

### DIFF
--- a/src/app/components/atoms/BeachDecorations.test.tsx
+++ b/src/app/components/atoms/BeachDecorations.test.tsx
@@ -1,0 +1,82 @@
+// ビーチ装飾コンポーネント（Issue #228 UI刷新 6 / TDD 先行）の契約を固定する単体テスト。
+//
+// #228 要件2 はライトモードのフッター上端に「上に飛び出す」ビーチの小物（浮き輪・くまで 等）を
+// インライン SVG で描画する。装飾は次を満たす必要がある:
+//   - aria-hidden="true"（支援技術から隠す純装飾）
+//   - pointer-events-none（クリック不可・レイアウトシフトを起こさない）
+//   - absolute 配置（通常フローに影響しない＝レイアウトシフト防止）
+//   - dark:hidden（ダークモードの夜フッターを崩さないよう非表示）
+// 本テストは BeachDecorations のルート要素が持つこれらの契約を固定する。SVG の見た目
+// （浮き輪/くまでの形状）はテスト対象にせず、機械検証可能なアクセシビリティ/配置契約に絞る。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は BeachDecorations が未作成のため import エラーで RED、実装後に GREEN。
+
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+// css import があってもテストが落ちないよう解決フックを張る（既存テストと同方針）
+const resolveHook = `
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.endsWith('.css')) {
+    return { url: 'data:text/javascript,export default {}', shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}
+`
+register(
+  'data:text/javascript,' + encodeURIComponent(resolveHook),
+  import.meta.url,
+)
+;(globalThis as Record<string, unknown>).React = React
+
+let BeachDecorations: React.FC
+before(async () => {
+  BeachDecorations = (await import('./BeachDecorations'))
+    .default as unknown as React.FC
+}) // ← import エラー時は before が失敗し、全サブテストが RED になる
+
+const render = (): string => renderToStaticMarkup(<BeachDecorations />)
+
+// 先頭のルート開始タグを取り出す（ルート要素に付いた属性/クラスを個別検証するため）
+const rootTag = (html: string): string => {
+  const match = html.match(/^<[^>]+>/)
+  assert.ok(match, 'ルート要素の開始タグが存在する')
+  return match![0]
+}
+
+test('BeachDecorations: 例外なく描画される', () => {
+  // Given/When/Then: SSR 描画で throw しない
+  assert.doesNotThrow(() => render())
+})
+
+test('BeachDecorations: ルートが aria-hidden="true" で支援技術から隠される', () => {
+  // Given/When: 装飾を描画する
+  const root = rootTag(render())
+  // Then: 純装飾のためアクセシビリティツリーから除外される
+  assert.ok(root.includes('aria-hidden="true"'), 'aria-hidden="true" を持つ')
+})
+
+test('BeachDecorations: ルートが pointer-events-none でクリック不可である', () => {
+  // Given/When: 装飾を描画する
+  const root = rootTag(render())
+  // Then: ポインタイベントを受けない（クリック不可・操作阻害しない）
+  assert.ok(root.includes('pointer-events-none'), 'pointer-events-none を持つ')
+})
+
+test('BeachDecorations: ルートが absolute 配置でレイアウトに影響しない', () => {
+  // Given/When: 装飾を描画する
+  const root = rootTag(render())
+  // Then: 通常フロー外に配置しレイアウトシフトを起こさない
+  assert.ok(root.includes('absolute'), 'absolute を持つ')
+})
+
+test('BeachDecorations: ルートが dark:hidden でダークモードでは非表示になる', () => {
+  // Given/When: 装飾を描画する
+  const root = rootTag(render())
+  // Then: 夜フッターを崩さないよう装飾はダークで隠す
+  assert.ok(root.includes('dark:hidden'), 'dark:hidden を持つ')
+})

--- a/src/app/components/atoms/BeachDecorations.tsx
+++ b/src/app/components/atoms/BeachDecorations.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+
+// ライトモードのフッター上端に「上に飛び出す」形で置くビーチ装飾（純装飾）。
+// - aria-hidden / pointer-events-none: 支援技術から隠し、クリック不可にする
+// - absolute + -translate-y-full: 通常フロー外に置きフッター上端の外側へせり出す（レイアウトシフトなし）
+// - dark:hidden: 夜フッターを崩さないためダークでは非表示
+// 配置は固定。窮屈さを避けるため、貝殻・ヒトデはモバイル（sm 未満）で非表示にする。
+const BeachDecorations: React.FC = () => {
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-x-0 top-0 z-10 h-14 -translate-y-full select-none dark:hidden"
+    >
+      {/* 浮き輪 */}
+      <svg
+        className="absolute bottom-0 left-6 md:left-12"
+        width="48"
+        height="48"
+        viewBox="0 0 48 48"
+        fill="none"
+      >
+        <circle cx="24" cy="24" r="20" fill="#FFFFFF" opacity="0.9" />
+        <circle
+          cx="24"
+          cy="24"
+          r="20"
+          fill="none"
+          stroke="#E95B6B"
+          strokeWidth="8"
+        />
+        <path
+          d="M24 4 A20 20 0 0 1 44 24"
+          stroke="#FFFFFF"
+          strokeWidth="8"
+          fill="none"
+        />
+        <path
+          d="M24 44 A20 20 0 0 1 4 24"
+          stroke="#FFFFFF"
+          strokeWidth="8"
+          fill="none"
+        />
+        <circle cx="24" cy="24" r="9" fill="#F3E9D2" />
+      </svg>
+
+      {/* くまで（砂遊び用の熊手） */}
+      <svg
+        className="absolute bottom-0 left-24 md:left-40"
+        width="40"
+        height="52"
+        viewBox="0 0 40 52"
+        fill="none"
+      >
+        <rect x="18" y="2" width="4" height="34" rx="2" fill="#B98A4B" />
+        <rect x="6" y="34" width="28" height="6" rx="3" fill="#33A597" />
+        <rect x="8" y="38" width="3" height="10" rx="1.5" fill="#33A597" />
+        <rect x="15" y="38" width="3" height="12" rx="1.5" fill="#33A597" />
+        <rect x="22" y="38" width="3" height="12" rx="1.5" fill="#33A597" />
+        <rect x="29" y="38" width="3" height="10" rx="1.5" fill="#33A597" />
+      </svg>
+
+      {/* ヒトデ（モバイルでは非表示） */}
+      <svg
+        className="absolute bottom-0 right-24 hidden sm:block md:right-40"
+        width="36"
+        height="36"
+        viewBox="0 0 36 36"
+        fill="none"
+      >
+        <path
+          d="M18 2 L22 13 L34 13 L24 20 L28 32 L18 25 L8 32 L12 20 L2 13 L14 13 Z"
+          fill="#F2A65A"
+          opacity="0.9"
+        />
+      </svg>
+
+      {/* 貝殻（モバイルでは非表示） */}
+      <svg
+        className="absolute bottom-0 right-8 hidden sm:block md:right-16"
+        width="34"
+        height="30"
+        viewBox="0 0 34 30"
+        fill="none"
+      >
+        <path
+          d="M17 28 C4 28 2 12 17 3 C32 12 30 28 17 28 Z"
+          fill="#F6C6C9"
+          opacity="0.9"
+        />
+        <path
+          d="M17 4 L17 27 M9 8 L14 26 M25 8 L20 26"
+          stroke="#E39FA3"
+          strokeWidth="1.5"
+          fill="none"
+        />
+      </svg>
+    </div>
+  )
+}
+
+export default BeachDecorations

--- a/src/app/components/templates/Footer.beach.test.tsx
+++ b/src/app/components/templates/Footer.beach.test.tsx
@@ -1,0 +1,186 @@
+// フッター砂浜テーマ刷新（Issue #228 UI刷新 6 / TDD 先行）の契約を固定する単体テスト。
+//
+// #228 は Footer に以下を導入する:
+//   - コピーライトを「© {年} Furugen Island」表示（年は new Date().getFullYear() で動的生成）
+//   - SNS リンクに Zenn / note を追加（外部リンクは target="_blank" rel="noopener noreferrer"）
+//   - フッター上端に飛び出すビーチ装飾（aria-hidden・クリック不可・ダーク非表示）
+//   - モバイル固定高さ h-32 の解消（h-auto md:h-32 へ）
+// 本テストはレンダリング結果（renderToStaticMarkup）の観測可能な契約を固定する。
+//
+// Footer は useI18n（@/i18n）に依存するため、既存 Footer.style.test.tsx と同様に実際の
+// I18nProvider でラップする。renderToStaticMarkup は useEffect を実行しないためロケールは
+// defaultLocale（ja）。next/link と、内部 AnimatedLine が使う next/navigation(usePathname) は
+// resolve フックでモックへ張り替える。next/link モックは href/className/target/rel を <a> へ写す。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は旧コピーライト・Zenn/note 未追加・装飾未実装のため RED、実装後に GREEN。
+
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+const linkMock =
+  'data:text/javascript,' +
+  encodeURIComponent(
+    "export default function Link(props){return React.createElement('a',{href:props.href,className:props.className,target:props.target,rel:props.rel},props.children)}",
+  )
+
+const navMock =
+  'data:text/javascript,' +
+  encodeURIComponent("export function usePathname(){return '/'}")
+
+const resolveHook = `
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.endsWith('.css')) {
+    return { url: 'data:text/javascript,export default {}', shortCircuit: true }
+  }
+  if (specifier === 'next/link') {
+    return { url: ${JSON.stringify(linkMock)}, shortCircuit: true }
+  }
+  if (specifier === 'next/navigation') {
+    return { url: ${JSON.stringify(navMock)}, shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}
+`
+register(
+  'data:text/javascript,' + encodeURIComponent(resolveHook),
+  import.meta.url,
+)
+;(globalThis as Record<string, unknown>).React = React
+
+let Footer: React.FC
+let I18nProvider: React.FC<{ children: React.ReactNode }>
+before(async () => {
+  Footer = (await import('./Footer')).default as unknown as React.FC
+  I18nProvider = (await import('../../../i18n/context'))
+    .I18nProvider as unknown as React.FC<{ children: React.ReactNode }>
+})
+
+const render = (): string =>
+  renderToStaticMarkup(
+    <I18nProvider>
+      <Footer />
+    </I18nProvider>,
+  )
+
+// 指定 href を持つ <a> 開始タグ文字列を抽出する（属性の付与を個別リンク単位で検証するため）
+const anchorFor = (html: string, href: string): string | null => {
+  const escaped = href.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = html.match(new RegExp(`<a[^>]*href="${escaped}"[^>]*>`))
+  return match ? match[0] : null
+}
+
+test('Footer: 例外なく描画される', () => {
+  // Given/When/Then: 刷新後も SSR 描画で throw しない
+  assert.doesNotThrow(() => render())
+})
+
+test('Footer: コピーライトが Furugen Island 名義で描画される', () => {
+  // Given/When: フッターを描画する
+  const html = render()
+  // Then: 新名義が出力される
+  assert.ok(html.includes('Furugen Island'), 'Furugen Island を含む')
+})
+
+test('Footer: コピーライトの年が new Date().getFullYear() で動的生成される', () => {
+  // Given: 実行時の現在年
+  const year = String(new Date().getFullYear())
+  // When: フッターを描画する
+  const html = render()
+  // Then: 現在年が描画され、旧固定表記「© 2024 furugen」は残っていない
+  assert.ok(html.includes(year), `現在年 ${year} を含む`)
+  assert.ok(!html.includes('© 2024 furugen'), '旧コピーライト表記を含まない')
+})
+
+test('Footer: Zenn リンクが新規タブ属性付きで描画される', () => {
+  // Given/When: フッターを描画する
+  const html = render()
+  // Then: 指定 URL の <a> に target/rel が付与されている
+  const anchor = anchorFor(html, 'https://zenn.dev/motoshifurugen')
+  assert.ok(anchor, 'Zenn リンクが存在する')
+  assert.ok(anchor!.includes('target="_blank"'), 'target="_blank" を持つ')
+  assert.ok(
+    anchor!.includes('rel="noopener noreferrer"'),
+    'rel="noopener noreferrer" を持つ',
+  )
+})
+
+test('Footer: note リンクが新規タブ属性付きで描画される', () => {
+  // Given/When: フッターを描画する
+  const html = render()
+  // Then: 指定 URL の <a> に target/rel が付与されている
+  const anchor = anchorFor(html, 'https://note.com/cocoa_hearts21')
+  assert.ok(anchor, 'note リンクが存在する')
+  assert.ok(anchor!.includes('target="_blank"'), 'target="_blank" を持つ')
+  assert.ok(
+    anchor!.includes('rel="noopener noreferrer"'),
+    'rel="noopener noreferrer" を持つ',
+  )
+})
+
+test('Footer: 既存 GitHub / X リンクが維持される', () => {
+  // Given/When: フッターを描画する
+  const html = render()
+  // Then: URL 定数化後も従来の 2 リンクが残る
+  assert.ok(
+    anchorFor(html, 'https://github.com/motoshifurugen'),
+    'GitHub リンクが存在する',
+  )
+  assert.ok(
+    anchorFor(html, 'https://x.com/cocoahearts21'),
+    'X リンクが存在する',
+  )
+})
+
+// NOTE: ビーチ装飾の aria-hidden / pointer-events-none / dark:hidden といった属性契約は
+// BeachDecorations.test.tsx（コンポーネント単体）で固定する。Footer html には FontAwesome の
+// faPlane が常に aria-hidden 付き svg を出力するため、Footer レベルで aria-hidden の有無を
+// 見ても装飾の契約にはならない（既存アイコンで誤って pass する）ため、ここでは検査しない。
+
+test('Footer: モバイル固定高さ h-32 単独を解消し h-auto を用いる', () => {
+  // Given/When: フッターを描画する
+  const html = render()
+  // Then: モバイル縦積みであふれないよう h-auto を持つ
+  assert.ok(html.includes('h-auto'), 'h-auto を含む')
+})
+
+test('Footer: ライトモードで砂浜背景トークン bg-sand を用いる', () => {
+  // Given/When: フッターを描画する
+  const html = render()
+  // Then: light 背景が砂色トークン、dark は従来の night-black を維持する
+  assert.ok(html.includes('bg-sand'), 'bg-sand を含む')
+  assert.ok(
+    html.includes('dark:bg-night-black'),
+    'dark:bg-night-black を維持する',
+  )
+})
+
+// family_tag: dry-violation の再発防止。SNS アイコンリンク（GitHub/X/Zenn）は共通の描画で
+// target/rel を必ず付与する。個別コピペに戻すと属性の付け忘れが起こり得るため、全アイコン
+// リンクが一様に外部リンク属性を持つことを固定し、DRY 逸脱の回帰を検知する。
+test('Footer: SNS アイコンリンクは一様に target/rel を持つ', () => {
+  // Given: 集約された SNS アイコンリンクの URL 群
+  const iconHrefs = [
+    'https://github.com/motoshifurugen',
+    'https://x.com/cocoahearts21',
+    'https://zenn.dev/motoshifurugen',
+  ]
+  // When: フッターを描画する
+  const html = render()
+  // Then: すべてのアイコンリンクが新規タブ属性を一様に備える
+  for (const href of iconHrefs) {
+    const anchor = anchorFor(html, href)
+    assert.ok(anchor, `${href} のリンクが存在する`)
+    assert.ok(
+      anchor!.includes('target="_blank"'),
+      `${href}: target="_blank" を持つ`,
+    )
+    assert.ok(
+      anchor!.includes('rel="noopener noreferrer"'),
+      `${href}: rel="noopener noreferrer" を持つ`,
+    )
+  }
+})

--- a/src/app/components/templates/Footer.tsx
+++ b/src/app/components/templates/Footer.tsx
@@ -1,81 +1,97 @@
 'use client'
 
+import { externalLinks } from '@/config/links'
 import { useI18n } from '@/i18n'
 import { faPlane } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Link from 'next/link'
 import { FaGithub } from 'react-icons/fa'
 import { FaXTwitter } from 'react-icons/fa6'
+import { SiZenn } from 'react-icons/si'
 import AnimatedLine from '../atoms/AnimatedLine'
+import BeachDecorations from '../atoms/BeachDecorations'
+
+const iconLinks = [
+  { href: externalLinks.github, Icon: FaGithub, label: 'GitHub' },
+  { href: externalLinks.x, Icon: FaXTwitter, label: 'X' },
+  { href: externalLinks.zenn, Icon: SiZenn, label: 'Zenn' },
+]
 
 export default function Footer() {
   const { t } = useI18n()
+  const year = new Date().getFullYear()
 
   return (
-    <>
-      <div className="relative z-20 bg-main-white py-10 dark:bg-night-black">
+    <div className="relative z-20 bg-sand py-10 dark:bg-night-black">
+      <BeachDecorations />
+      {/* 砂浜と干渉するため AnimatedLine はダークのみ表示（#228） */}
+      <div className="hidden dark:block">
         <AnimatedLine />
-        <footer>
-          <div className="container mx-auto p-4">
-            <div className="container mt-4 h-32 md:flex">
-              <div className="rightFooter w-full select-none md:w-3/4">
-                <p className="mb-1 text-lg md:mb-3">Motoshi Furugen</p>
-                <p className="flex items-center">
-                  {t.footer.cities.oka}
-                  <FontAwesomeIcon
-                    icon={faPlane}
-                    className="mx-1 text-xs opacity-70"
-                  />
-                  {t.footer.cities.hij}
-                  <FontAwesomeIcon
-                    icon={faPlane}
-                    className="mx-1 text-xs opacity-70"
-                  />
-                  {t.footer.cities.tyo}
-                  <FontAwesomeIcon
-                    icon={faPlane}
-                    className="mx-1 text-xs opacity-70"
-                  />
-                  {t.footer.cities.bcd}
-                </p>
-              </div>
-              <div
-                className="
+      </div>
+      <footer>
+        <div className="container mx-auto p-4">
+          <div className="container mt-4 h-auto md:flex md:h-32">
+            <div className="rightFooter w-full select-none md:w-3/4">
+              <p className="mb-1 text-lg md:mb-3">Motoshi Furugen</p>
+              <p className="flex items-center">
+                {t.footer.cities.oka}
+                <FontAwesomeIcon
+                  icon={faPlane}
+                  className="mx-1 text-xs opacity-70"
+                />
+                {t.footer.cities.hij}
+                <FontAwesomeIcon
+                  icon={faPlane}
+                  className="mx-1 text-xs opacity-70"
+                />
+                {t.footer.cities.tyo}
+                <FontAwesomeIcon
+                  icon={faPlane}
+                  className="mx-1 text-xs opacity-70"
+                />
+                {t.footer.cities.bcd}
+              </p>
+            </div>
+            <div
+              className="
               my-4 border-l-0
               border-t-2 opacity-40
               md:mx-8
               md:my-0 md:border-l-2 md:border-t-0
             "
-              ></div>
-              <div className="leftFooter flex w-full flex-col justify-between md:w-1/4">
-                <div className="mb-6 flex space-x-6 md:mb-0">
+            ></div>
+            <div className="leftFooter flex w-full flex-col justify-between md:w-1/4">
+              <div className="mb-6 flex items-center space-x-6 md:mb-0">
+                {iconLinks.map(({ href, Icon, label }) => (
                   <Link
-                    href="https://github.com/motoshifurugen"
+                    key={label}
+                    href={href}
                     rel="noopener noreferrer"
                     target="_blank"
                   >
                     <div className="text-main-black dark:text-night-white">
-                      <FaGithub size={24} />
+                      <Icon size={24} />
                     </div>
                   </Link>
-                  <Link
-                    href="https://x.com/cocoahearts21"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    <div className="text-main-black dark:text-night-white">
-                      <FaXTwitter size={24} />
-                    </div>
-                  </Link>
-                </div>
-                <p className="select-none self-end opacity-50">
-                  {t.footer.copyright}
-                </p>
+                ))}
+                {/* note は react-icons に SiNote が無くテキスト表示のため構造が異なり個別に描画する */}
+                <Link
+                  href={externalLinks.note}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <div className="text-lg font-bold text-main-black dark:text-night-white">
+                    note
+                  </div>
+                </Link>
               </div>
+              <p className="select-none self-end opacity-50">
+                © {year} {t.footer.copyright}
+              </p>
             </div>
           </div>
-        </footer>
-      </div>
-    </>
+        </div>
+      </footer>
+    </div>
   )
 }

--- a/src/config/links.test.ts
+++ b/src/config/links.test.ts
@@ -1,0 +1,43 @@
+// 外部リンクURL集約モジュール（Issue #228 UI刷新 6 / TDD 先行）の契約を固定する単体テスト。
+//
+// #228 要件4 は Footer 内に散在していた GitHub / X の URL に加え、新規の Zenn / note を
+// 1 箇所（src/config/links.ts）へ集約し、ブログページ側（別イシュー）からも参照可能な
+// 名前付きエクスポートとして公開することを求める。本テストはその公開 API（externalLinks）
+// が公開する「キー」と「URL 値」を固定し、Footer 側のハードコード回帰・URL 誤りを防ぐ。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は src/config/links.ts が未作成のため import エラーで RED、実装後に GREEN。
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { externalLinks } from './links'
+
+test('externalLinks: github は本人の GitHub プロフィール URL である', () => {
+  // Given/When/Then: 既存 Footer のハードコード URL を定数へ移設する
+  assert.equal(externalLinks.github, 'https://github.com/motoshifurugen')
+})
+
+test('externalLinks: x は本人の X プロフィール URL である', () => {
+  // Given/When/Then: 既存 Footer のハードコード URL を定数へ移設する
+  assert.equal(externalLinks.x, 'https://x.com/cocoahearts21')
+})
+
+test('externalLinks: zenn は指定された Zenn プロフィール URL である', () => {
+  // Given/When/Then: #228 で新規追加する SNS リンク
+  assert.equal(externalLinks.zenn, 'https://zenn.dev/motoshifurugen')
+})
+
+test('externalLinks: note は指定された note プロフィール URL である', () => {
+  // Given/When/Then: #228 で新規追加する SNS リンク
+  assert.equal(externalLinks.note, 'https://note.com/cocoa_hearts21')
+})
+
+test('externalLinks: すべての値が https の外部 URL である', () => {
+  // Given: 集約された全リンク
+  const urls = Object.values(externalLinks)
+  // When/Then: 外部リンクとして https から始まる（新規タブ・rel 付与の前提）
+  assert.ok(urls.length >= 4, 'github/x/zenn/note の 4 つ以上を公開する')
+  for (const url of urls) {
+    assert.match(url, /^https:\/\//, `${url} が https 始まりである`)
+  }
+})

--- a/src/config/links.ts
+++ b/src/config/links.ts
@@ -1,0 +1,9 @@
+// 外部リンク（SNS プロフィール）URL を 1 箇所へ集約する。
+// Footer 以外（ブログページ等）からも参照できるよう名前付きエクスポートで公開する。
+
+export const externalLinks = {
+  github: 'https://github.com/motoshifurugen',
+  x: 'https://x.com/cocoahearts21',
+  zenn: 'https://zenn.dev/motoshifurugen',
+  note: 'https://note.com/cocoa_hearts21',
+} as const

--- a/src/i18n/footer-copyright.test.ts
+++ b/src/i18n/footer-copyright.test.ts
@@ -1,0 +1,44 @@
+// コピーライト名義変更（Issue #228 UI刷新 6 / TDD 先行）の契約を固定する単体テスト。
+//
+// #228 要件3 は Footer のコピーライトを「furugen」名義から「Furugen Island」名義へ変更し、
+// 年は Footer 側で new Date().getFullYear() により自動更新する。したがって
+// translations の copyright は年やコピーライト記号を含まず、名義文字列のみを持つ設計とする。
+// 本テストは ja / en 両ロケールの copyright 値を固定し、旧表記「© 2024 furugen」の残存と
+// 片側ロケール取り残しを防ぐ。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は旧値「© 2024 furugen」のため RED、実装後に GREEN。
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { translations } from './translations'
+
+test('ja: copyright が Furugen Island 名義である', () => {
+  // Given/When/Then: ja ロケールの copyright
+  assert.equal(translations.ja.footer.copyright, 'Furugen Island')
+})
+
+test('en: copyright が Furugen Island 名義である', () => {
+  // Given/When/Then: en ロケールの copyright（片側取り残し防止）
+  assert.equal(translations.en.footer.copyright, 'Furugen Island')
+})
+
+test('copyright: 旧名義 furugen（小文字）を含まない', () => {
+  // Given/When/Then: 旧表記が両ロケールから除去されている
+  for (const locale of ['ja', 'en'] as const) {
+    assert.ok(
+      !translations[locale].footer.copyright.includes('furugen'),
+      `${locale}: 旧名義 furugen を含まない`,
+    )
+  }
+})
+
+test('copyright: 年をハードコードしない（2024 を含まない）', () => {
+  // Given/When/Then: 年は Footer 側で動的生成するため文字列に含めない
+  for (const locale of ['ja', 'en'] as const) {
+    assert.ok(
+      !translations[locale].footer.copyright.includes('2024'),
+      `${locale}: 年 2024 をハードコードしない`,
+    )
+  }
+})

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -28,7 +28,7 @@ export const translations: Translations = {
       closeMenu: 'メニューを閉じる',
     },
     footer: {
-      copyright: '© 2024 furugen',
+      copyright: 'Furugen Island',
       cities: {
         oka: '沖縄',
         hij: '広島',
@@ -269,7 +269,7 @@ export const translations: Translations = {
       closeMenu: 'Close menu',
     },
     footer: {
-      copyright: '© 2024 furugen',
+      copyright: 'Furugen Island',
       cities: {
         oka: 'Okinawa',
         hij: 'Hiroshima',

--- a/src/tailwind.config.sand.test.ts
+++ b/src/tailwind.config.sand.test.ts
@@ -1,0 +1,29 @@
+// 砂色トークン追加（Issue #228 UI刷新 6 / TDD 先行）の契約を固定する単体テスト。
+//
+// #228 要件1 はライトモードのフッター背景を「砂浜」にするため、tailwind.config.ts の
+// theme.extend.colors に砂色トークン sand を追加する（Issue 提示例 #F3E9D2）。
+// クラス名（bg-sand）を eslint-plugin-tailwindcss の no-custom-classname 検査でも通すには
+// config への定義が前提となるため、本テストは config が公開する sand トークンの存在と
+// 値の形式（#RRGGBB）を固定する。具体的な hex は Issue 上「例」であり実装者裁量のため
+// 一致ではなく「有効な hex であること」を検証する。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は sand 未定義のため RED、実装後に GREEN。
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import config from '../tailwind.config'
+
+const extend = (config.theme as { extend?: Record<string, unknown> }).extend
+
+const isHex = (value: unknown): value is string =>
+  typeof value === 'string' && /^#[0-9a-fA-F]{6}$/.test(value)
+
+test('colors.sand: 砂色トークンが定義されている', () => {
+  // Given: theme.extend.colors
+  assert.ok(extend, 'theme.extend が定義されている')
+  const colors = extend.colors as Record<string, unknown> | undefined
+  assert.ok(colors, 'theme.extend.colors が定義されている')
+  // When/Then: sand トークンが有効な #RRGGBB で存在する
+  assert.ok(isHex(colors.sand), 'colors.sand が #RRGGBB 形式で定義されている')
+})

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,6 +19,7 @@ const config: Config = {
         'night-gray': '#4B4B5A',
         'night-orange': '#FBBF24',
         'like-pink': '#E95B6B',
+        sand: '#F3E9D2',
         white: '#FFFFFF',
         gray: '#E5E7E6',
         teal: {


### PR DESCRIPTION
## 概要
GitHub Issue #228「UI刷新(6): ライトモードのフッターを砂浜テーマに＋コピーライトを Furugen Island へ」を takt（default workflow: テスト先行）で実装。

## 背景

フッター（`src/app/components/templates/Footer.tsx`）が無地（light=`bg-main-white`）で世界観（島・海）が出ていない。**ライトモードのフッターを「砂浜」**にし、ビーチのオブジェクトで遊び心を足す。ダークモードは現状の夜テーマ（`night-black`）を維持する。あわせてコピーライト表記を更新する。

前提: #223〜#227 マージ済み（新トークン・新タイポスケールに合わせる）。

## 変更内容

### 1. 砂浜配色（ライトモードのみ）
- `tailwind.config.ts` に砂色トークンを追加（例: `sand: '#F3E9D2'` 前後、上→下へ淡いグラデ可）し、フッター背景を light では砂浜色に。`dark:bg-night-black` は変更しない
- 本文・リンク・コピーライトのコントラストは WCAG AA 目安を維持

### 2. フッター上部に飛び出すビーチオブジェクト
- フッター上端に**上に飛び出す形で**ビーチの小物を配置: 浮き輪・くまで（砂遊び用の熊手）を必須とし、貝殻やヒトデ等を1〜2点足してよい
- 実装はインラインSVG（フラット・線は控えめ・既存の雲/星の装飾と同じくらい主張しないトーン）。`absolute` + 負のオフセットでフッター境界にまたがらせ、`overflow` に注意
- 配置はランダムでなく固定。モバイルでは点数を減らすか縮小して窮屈にしない
- **ダークモードでは非表示**（現状の夜フッターを崩さない）
- 装飾は `aria-hidden` とし、クリック不可・レイアウトシフトを起こさないこと
- 既存の `AnimatedLine`（フッター先頭の細線）は砂浜と干渉するなら light では非表示にしてよい

### 3. コピーライト表記の変更
- `src/i18n/translations.ts` の ja/en 両方: `© 2024 furugen` → **`Furugen Island`** 名義へ変更
- 年は Footer 側で `new Date().getFullYear()` を使い自動更新にする（表記例: `© 2026 Furugen Island`）

### 4. SNSリンクに Zenn / note を追加
- 既存の GitHub / X アイコン列に **Zenn**（https://zenn.dev/motoshifurugen）と **note**（https://note.com/cocoa_hearts21）を追加
- アイコンは `react-icons`（`SiZenn` / `SiNote` があれば使用、無ければ簡潔なテキストリンクで可）。サイズ・色・hover は既存2つと揃える
- 外部リンクは `target="_blank" rel="noopener noreferrer"`
- URL定数は1箇所（例: `src/config/links.ts`）にまとめ、ブログページ側（別イシュー）からも参照できるようにする

## 完了条件
- `npm run build` 成功、`npm run lint` パス
- ライト: 砂浜配色＋浮き輪・くまでがフッター上端に飛び出して見える／ダーク: 従来どおり
- コピーライトが「© {年} Furugen Island」表示（ja/en とも）
- Zenn/note リンクが両テーマで自然に見え、新規タブで開く

## 追補（2026-07-02 CEOレビュー: モバイルレイアウト）

- **固定高さの解消**: 現状 `Footer.tsx` の `<div className="container mt-4 h-32 md:flex">` はモバイル縦積み時に内容が 128px を超えてあふれる/詰まる。`h-auto md:h-32` に変更し、モバイルは内容に応じた高さ＋十分な縦余白を確保すること（本イシューのフッター改修に含める）

---
Workflow `default` completed successfully.

Closes #228

🤖 Generated with takt + Claude Code