### PR TITLE
[#229] ブログをハブ化: Zenn / note チャンネルカードの常設＋立ち位置の明文化

### DIFF
--- a/src/app/components/molecules/ChannelCard.test.tsx
+++ b/src/app/components/molecules/ChannelCard.test.tsx
@@ -1,0 +1,147 @@
+// 発信チャンネルカード（molecule ChannelCard）の契約を固定する単体テスト
+// （Issue #229 ブログのハブ化 / TDD 先行）。
+//
+// #229 はブログ index に Zenn / note への外部導線カードを常設する。ChannelCard は
+// その 1 枚を描画する汎用 molecule で、props は次の shape を取る:
+//   { href: string; icon: React.ReactNode; label: string }
+// note には react-icons の該当アイコンが無いためテキスト "note" を、Zenn には <SiZenn/> を
+// 呼び出し側が icon として渡す。したがって ChannelCard 自身はアイコン種別を知らず ReactNode で受ける。
+//
+// 観測可能な契約（本テストで固定するもの）:
+//   - href を持つ <a> を 1 つ描画する
+//   - 外部リンクとして target="_blank" rel="noopener noreferrer" を必ず付与する（完了条件・セキュリティ）
+//   - 渡された label（一言）を描画する
+//   - 渡された icon ノードを描画する
+//   - ダーク対応（dark: プレフィックスの className を持つ）
+//   - 記事一覧より主張しない＝ホバー浮き上がり（hover:-translate-y）を付けない（plan 明記）
+//
+// 既存 BlogCard.style.test.tsx / Footer.beach.test.tsx と同じく node:test と
+// renderToStaticMarkup のみで構成し、CSS Module と next/link を resolve フックでモックする。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は ChannelCard 未作成のため import エラーで RED、実装後に GREEN。
+
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+// 外部リンクは素の <a> が標準だが、実装が next/link を用いても href/target/rel が
+// <a> へ写るようモックしておく（描画契約は実装手段に依存させない）。
+const linkMock =
+  'data:text/javascript,' +
+  encodeURIComponent(
+    "export default function Link(props){return React.createElement('a',{href:props.href,className:props.className,target:props.target,rel:props.rel},props.children)}",
+  )
+
+const resolveHook = `
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.endsWith('.css')) {
+    return { url: 'data:text/javascript,export default {}', shortCircuit: true }
+  }
+  if (specifier === 'next/link') {
+    return { url: ${JSON.stringify(linkMock)}, shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}
+`
+register(
+  'data:text/javascript,' + encodeURIComponent(resolveHook),
+  import.meta.url,
+)
+;(globalThis as Record<string, unknown>).React = React
+
+interface ChannelCardProps {
+  href: string
+  icon: React.ReactNode
+  label: string
+}
+
+let ChannelCard: React.FC<ChannelCardProps>
+before(async () => {
+  ChannelCard = (await import('./ChannelCard'))
+    .default as unknown as React.FC<ChannelCardProps>
+})
+
+const HREF = 'https://example.com/channel'
+const LABEL = 'テスト用の一言ラベル'
+const ICON_MARK = 'ICON_MARK_TOKEN'
+
+const icon = () => React.createElement('span', null, ICON_MARK)
+
+const render = (props?: Partial<ChannelCardProps>): string =>
+  renderToStaticMarkup(
+    <ChannelCard href={HREF} icon={icon()} label={LABEL} {...props} />,
+  )
+
+// 指定 href を持つ <a> 開始タグ文字列を抽出する（属性をリンク単位で検証するため）
+const anchorFor = (html: string, href: string): string | null => {
+  const escaped = href.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = html.match(new RegExp(`<a[^>]*href="${escaped}"[^>]*>`))
+  return match ? match[0] : null
+}
+
+test('ChannelCard: 例外なく描画される', () => {
+  // Given/When/Then: props を渡して描画しても throw しない
+  assert.doesNotThrow(() => render())
+})
+
+test('ChannelCard: href を持つ <a> を描画する', () => {
+  // Given/When: カードを描画する
+  const html = render()
+  // Then: 渡した href の <a> が存在する
+  assert.ok(anchorFor(html, HREF), '指定 href の <a> が存在する')
+})
+
+test('ChannelCard: 外部リンクとして target="_blank" を付与する', () => {
+  // Given/When: カードを描画する
+  const html = render()
+  // Then: 新規タブで開く
+  const anchor = anchorFor(html, HREF)
+  assert.ok(anchor, 'リンクが存在する')
+  assert.ok(anchor!.includes('target="_blank"'), 'target="_blank" を持つ')
+})
+
+test('ChannelCard: 外部リンクとして rel="noopener noreferrer" を付与する', () => {
+  // Given/When: カードを描画する
+  const html = render()
+  // Then: セキュリティ上の rel が付与される（完了条件）
+  const anchor = anchorFor(html, HREF)
+  assert.ok(anchor, 'リンクが存在する')
+  assert.ok(
+    anchor!.includes('rel="noopener noreferrer"'),
+    'rel="noopener noreferrer" を持つ',
+  )
+})
+
+test('ChannelCard: 渡された label（一言）を描画する', () => {
+  // Given/When: label を持つカードを描画する
+  const html = render()
+  // Then: ラベル文言が出力される
+  assert.ok(html.includes(LABEL), 'label が描画される')
+})
+
+test('ChannelCard: 渡された icon ノードを描画する', () => {
+  // Given/When: icon ノード（Zenn アイコンや "note" テキストに相当）を渡す
+  const html = render()
+  // Then: icon の内容が出力される（ReactNode をそのまま受けて描画する契約）
+  assert.ok(html.includes(ICON_MARK), 'icon ノードが描画される')
+})
+
+test('ChannelCard: ダークモード対応の className を持つ', () => {
+  // Given/When: カードを描画する
+  const html = render()
+  // Then: dark: プレフィックスの装飾がある（ライト/ダーク両対応の完了条件）
+  assert.match(html, /dark:/, 'dark: プレフィックスの className を含む')
+})
+
+test('ChannelCard: 記事一覧より主張しないためホバー浮き上がりを付けない', () => {
+  // Given/When: カードを描画する
+  const html = render()
+  // Then: BlogCard と異なり hover:-translate-y は付与しない（plan の控えめ装飾方針）
+  assert.ok(
+    !/hover:-translate-y-/.test(html),
+    'hover:-translate-y- を含まない（控えめな装飾）',
+  )
+})

--- a/src/app/components/molecules/ChannelCard.tsx
+++ b/src/app/components/molecules/ChannelCard.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { FiExternalLink } from 'react-icons/fi'
+
+interface ChannelCardProps {
+  href: string
+  icon: React.ReactNode
+  label: string
+}
+
+// 外部発信チャンネル（Zenn / note 等）への導線を 1 枚描画する汎用カード。
+// 記事一覧より主張しないよう、hover 浮き上がりを付けず border 主体の控えめな装飾にする（#229）。
+const ChannelCard: React.FC<ChannelCardProps> = ({ href, icon, label }) => {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center gap-3 rounded-lg border border-gray bg-white p-4 text-main-black transition-colors duration-300 hover:border-teal dark:border-night-gray dark:bg-night-gray dark:text-night-white dark:hover:border-night-teal"
+    >
+      <span className="text-2xl">{icon}</span>
+      <span className="flex-grow font-bold">{label}</span>
+      <FiExternalLink className="opacity-60" aria-hidden />
+    </a>
+  )
+}
+
+export default ChannelCard

--- a/src/app/components/organisms/ChannelLinks.test.tsx
+++ b/src/app/components/organisms/ChannelLinks.test.tsx
@@ -1,0 +1,167 @@
+// 発信チャンネル導線（organism ChannelLinks）の契約を固定する単体テスト
+// （Issue #229 ブログのハブ化 / TDD 先行）。
+//
+// #229 はブログ index の記事一覧の上に「他の場所でも書いています」枠として
+// Zenn / note の 2 カードを常設する。ChannelLinks は見出し＋2 カードを束ねる organism で、
+// URL は src/config/links.ts の externalLinks を、文言は i18n（t.blog.channels）を参照する。
+//
+// 本テストは観測可能な描画契約を固定する:
+//   - 例外なく描画される
+//   - Zenn / note それぞれの externalLinks URL の <a> が存在し、target/rel を持つ
+//   - 全チャンネルリンクが一様に外部リンク属性（target/rel）を持つ（DRY 逸脱の回帰検知）
+//   - URL は externalLinks を出所とする（ハードコード回帰の防止）
+//   - 見出し（t.blog.channels.heading の値）が描画される（文言の配線）
+//   - ブログカードは Zenn / note のみで、GitHub / X などフッター専用リンクは含めない（スコープ固定）
+//   - 記事一覧より主張しないためホバー浮き上がり（hover:-translate-y）を付けない
+//
+// 文言そのもの（プロダクト側で自然に調整可）は固定しない。翻訳キーの存在・非空は
+// i18n 契約テスト（src/i18n/blog-channels.test.ts）で別途固定する。ここでは翻訳「値」が
+// 実際に描画へ配線されていることのみ、translations から値を引いて確認する。
+//
+// Footer.beach.test.tsx と同じく I18nProvider でラップし（renderToStaticMarkup は useEffect を
+// 実行しないためロケールは defaultLocale=ja）、next/link・next/navigation・.css を resolve フックで
+// モックへ張り替える。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は ChannelLinks / t.blog.channels 未作成のため RED、実装後に GREEN。
+
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { externalLinks } from '../../../config/links'
+import { translations } from '../../../i18n/translations'
+
+const linkMock =
+  'data:text/javascript,' +
+  encodeURIComponent(
+    "export default function Link(props){return React.createElement('a',{href:props.href,className:props.className,target:props.target,rel:props.rel},props.children)}",
+  )
+
+const navMock =
+  'data:text/javascript,' +
+  encodeURIComponent(
+    "export function usePathname(){return '/'}\nexport function useRouter(){return {push(){},replace(){},prefetch(){},back(){},forward(){},refresh(){}}}\nexport function useSearchParams(){return {get(){return null}}}",
+  )
+
+const resolveHook = `
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.endsWith('.css')) {
+    return { url: 'data:text/javascript,export default {}', shortCircuit: true }
+  }
+  if (specifier === 'next/link') {
+    return { url: ${JSON.stringify(linkMock)}, shortCircuit: true }
+  }
+  if (specifier === 'next/navigation') {
+    return { url: ${JSON.stringify(navMock)}, shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}
+`
+register(
+  'data:text/javascript,' + encodeURIComponent(resolveHook),
+  import.meta.url,
+)
+;(globalThis as Record<string, unknown>).React = React
+
+let ChannelLinks: React.FC
+let I18nProvider: React.FC<{ children: React.ReactNode }>
+before(async () => {
+  ChannelLinks = (await import('./ChannelLinks')).default as unknown as React.FC
+  I18nProvider = (await import('../../../i18n/context'))
+    .I18nProvider as unknown as React.FC<{ children: React.ReactNode }>
+})
+
+const render = (): string =>
+  renderToStaticMarkup(
+    <I18nProvider>
+      <ChannelLinks />
+    </I18nProvider>,
+  )
+
+// 指定 href を持つ <a> 開始タグ文字列を抽出する（属性をリンク単位で検証するため）
+const anchorFor = (html: string, href: string): string | null => {
+  const escaped = href.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = html.match(new RegExp(`<a[^>]*href="${escaped}"[^>]*>`))
+  return match ? match[0] : null
+}
+
+test('ChannelLinks: 例外なく描画される', () => {
+  // Given/When/Then: SSR 描画で throw しない
+  assert.doesNotThrow(() => render())
+})
+
+test('ChannelLinks: Zenn カードが externalLinks の URL で新規タブ属性付きに描画される', () => {
+  // Given/When: 導線を描画する
+  const html = render()
+  // Then: externalLinks.zenn の <a> が target/rel 付きで存在する
+  const anchor = anchorFor(html, externalLinks.zenn)
+  assert.ok(anchor, 'Zenn リンクが存在する')
+  assert.ok(anchor!.includes('target="_blank"'), 'target="_blank" を持つ')
+  assert.ok(
+    anchor!.includes('rel="noopener noreferrer"'),
+    'rel="noopener noreferrer" を持つ',
+  )
+})
+
+test('ChannelLinks: note カードが externalLinks の URL で新規タブ属性付きに描画される', () => {
+  // Given/When: 導線を描画する
+  const html = render()
+  // Then: externalLinks.note の <a> が target/rel 付きで存在する
+  const anchor = anchorFor(html, externalLinks.note)
+  assert.ok(anchor, 'note リンクが存在する')
+  assert.ok(anchor!.includes('target="_blank"'), 'target="_blank" を持つ')
+  assert.ok(
+    anchor!.includes('rel="noopener noreferrer"'),
+    'rel="noopener noreferrer" を持つ',
+  )
+})
+
+test('ChannelLinks: 全チャンネルリンクが一様に target/rel を持つ（DRY 逸脱の回帰検知）', () => {
+  // Given: 常設する 2 チャンネルの URL
+  const hrefs = [externalLinks.zenn, externalLinks.note]
+  // When: 導線を描画する
+  const html = render()
+  // Then: すべてのカードリンクが一様に外部リンク属性を備える
+  for (const href of hrefs) {
+    const anchor = anchorFor(html, href)
+    assert.ok(anchor, `${href} のリンクが存在する`)
+    assert.ok(
+      anchor!.includes('target="_blank"'),
+      `${href}: target="_blank" を持つ`,
+    )
+    assert.ok(
+      anchor!.includes('rel="noopener noreferrer"'),
+      `${href}: rel="noopener noreferrer" を持つ`,
+    )
+  }
+})
+
+test('ChannelLinks: 見出し文言（t.blog.channels.heading の値）が描画される', () => {
+  // Given: 既定ロケール(ja)の見出し翻訳値
+  const heading = translations.ja.blog.channels.heading
+  // When: 導線を描画する
+  const html = render()
+  // Then: 翻訳値が実際に配線・描画されている（文言リテラルは固定しない）
+  assert.ok(heading.length > 0, '見出し翻訳が非空である')
+  assert.ok(html.includes(heading), '見出し翻訳値が描画される')
+})
+
+test('ChannelLinks: ブログカードは Zenn / note のみで GitHub / X を含めない（スコープ固定）', () => {
+  // Given/When: 導線を描画する
+  const html = render()
+  // Then: フッター専用の GitHub / X はブログのチャンネルカードには出さない
+  assert.ok(!anchorFor(html, externalLinks.github), 'GitHub リンクを含まない')
+  assert.ok(!anchorFor(html, externalLinks.x), 'X リンクを含まない')
+})
+
+test('ChannelLinks: 記事一覧より主張しないためホバー浮き上がりを付けない', () => {
+  // Given/When: 導線を描画する
+  const html = render()
+  // Then: BlogCard と異なり hover:-translate-y は使わない（plan の控えめ装飾方針）
+  assert.ok(
+    !/hover:-translate-y-/.test(html),
+    'hover:-translate-y- を含まない（控えめな装飾）',
+  )
+})

--- a/src/app/components/organisms/ChannelLinks.tsx
+++ b/src/app/components/organisms/ChannelLinks.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import ChannelCard from '@/app/components/molecules/ChannelCard'
+import { externalLinks } from '@/config/links'
+import { useI18n } from '@/i18n'
+import React from 'react'
+import { SiZenn } from 'react-icons/si'
+
+// ブログ index の「他の場所でも書いています」枠。Zenn / note への外部導線を常設する（#229）。
+// URL は src/config/links.ts の externalLinks、文言は i18n（t.blog.channels）を出所とする。
+const ChannelLinks: React.FC = () => {
+  const { t } = useI18n()
+
+  return (
+    <section aria-label={t.blog.channels.heading}>
+      <h2 className="mb-4 text-lg font-bold text-main-black dark:text-night-white">
+        {t.blog.channels.heading}
+      </h2>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <ChannelCard
+          href={externalLinks.zenn}
+          icon={<SiZenn />}
+          label={t.blog.channels.zenn}
+        />
+        {/* note は react-icons に該当アイコンが無いためテキスト "note" で表現する（Footer と同方針） */}
+        <ChannelCard
+          href={externalLinks.note}
+          icon={<span className="text-lg font-bold">note</span>}
+          label={t.blog.channels.note}
+        />
+      </div>
+    </section>
+  )
+}
+
+export default ChannelLinks

--- a/src/app/components/templates/ArticleList.tsx
+++ b/src/app/components/templates/ArticleList.tsx
@@ -2,6 +2,7 @@
 
 import AnimatedLine from '@/app/components/atoms/AnimatedLine'
 import BlogGrid from '@/app/components/organisms/BlogGrid'
+import ChannelLinks from '@/app/components/organisms/ChannelLinks'
 import PageFace from '@/app/components/organisms/PageFace'
 import styles from '@/app/components/templates/ArticleContent.module.css'
 import MaintenanceTemplate from '@/app/components/templates/MaintenanceTemplate'
@@ -59,7 +60,7 @@ const PostListView: React.FC<PostListViewProps> = ({ posts, selectedTag }) => {
   )
 }
 
-// useSearchParams は静的書き出しで <Suspense> 境界が必須のため、
+// useSearchParams は静的書き出しで Suspense 境界が必須のため、
 // タグ絞り込みはこの子コンポーネントに隔離する。
 const FilterablePostList: React.FC<ArticleListProps> = ({ initialPosts }) => {
   const searchParams = useSearchParams()
@@ -86,10 +87,18 @@ const ArticleList: React.FC<ArticleListProps> = ({ initialPosts }) => {
   return (
     <>
       <section>
-        <PageFace title={t.blog.title} subtitle="" mainMessage={<></>} />
+        <PageFace
+          title={t.blog.title}
+          subtitle=""
+          mainMessage={<p>{t.blog.lead}</p>}
+        />
       </section>
 
       <AnimatedLine />
+
+      <section className="mx-auto w-full max-w-screen-lg px-4 md:px-10">
+        <ChannelLinks />
+      </section>
 
       <section>
         <Suspense

--- a/src/app/components/templates/ArticleList.wiring.test.ts
+++ b/src/app/components/templates/ArticleList.wiring.test.ts
@@ -1,0 +1,62 @@
+// ブログ index への発信チャンネル導線の配線（Issue #229 / TDD 先行）を固定する結合テスト。
+//
+// #229 完了条件のうち「/blog 上部に Zenn / note カードが表示される」「PageFace に立ち位置の
+// 一言を添える」は、ChannelLinks 単体テストでは担保できない“ArticleList への組み込み位置”の
+// 契約である。ArticleList を renderToStaticMarkup で描画する案は、記事一覧配下の BlogGrid
+// （useLikeCounts の fetch）・Sidebar → ProfileCard（next/image）等の重い推移的依存を引き込み、
+// テストが壊れやすくなる（plan の申し送りでも ArticleList 全体描画は非推奨）。そこで本テストは
+// ArticleList.tsx のソース構造を読み、次の配線契約のみを最小限に固定する:
+//   - ChannelLinks を import している
+//   - JSX に <ChannelLinks を配置している
+//   - <ChannelLinks は記事一覧の <Suspense より前（＝上）に置かれている（常設・二重描画回避）
+//   - PageFace に t.blog.lead を配線している（subtitle/mainMessage が空でなくなる）
+//
+// トークン（import 名・<ChannelLinks・<Suspense・t.blog.lead）は Prettier 整形で安定するため、
+// 空白差異に依存しない構造契約として扱う。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は ChannelLinks 未配線・lead 未参照のため RED、実装後に GREEN。
+
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+const source = readFileSync(
+  new URL('./ArticleList.tsx', import.meta.url),
+  'utf8',
+)
+
+test('ArticleList: ChannelLinks を import している', () => {
+  // Given/When/Then: 導線コンポーネントを取り込んでいる
+  assert.match(
+    source,
+    /import\s+ChannelLinks\s+from\s+['"][^'"]*ChannelLinks['"]/,
+    'ChannelLinks の import が存在する',
+  )
+})
+
+test('ArticleList: JSX に <ChannelLinks を配置している', () => {
+  // Given/When/Then: 導線を実際に描画している
+  assert.ok(source.includes('<ChannelLinks'), '<ChannelLinks を含む')
+})
+
+test('ArticleList: ChannelLinks を記事一覧（<Suspense）より上に配置する', () => {
+  // Given: JSX 上の各要素の出現位置
+  const channelIndex = source.indexOf('<ChannelLinks')
+  const suspenseIndex = source.indexOf('<Suspense')
+  // Then: 記事一覧より前に導線が置かれている（記事一覧の“上”に常設する完了条件）
+  assert.ok(channelIndex >= 0, '<ChannelLinks が存在する')
+  assert.ok(suspenseIndex >= 0, '<Suspense（記事一覧）が存在する')
+  assert.ok(
+    channelIndex < suspenseIndex,
+    '<ChannelLinks は <Suspense より前に置かれる',
+  )
+})
+
+test('ArticleList: PageFace に立ち位置の一文（t.blog.lead）を配線する', () => {
+  // Given/When/Then: 空だった mainMessage/subtitle を lead 文言で埋める
+  assert.ok(
+    source.includes('t.blog.lead'),
+    't.blog.lead を参照して PageFace に配線する',
+  )
+})

--- a/src/i18n/blog-channels.test.ts
+++ b/src/i18n/blog-channels.test.ts
@@ -1,0 +1,69 @@
+// ブログのハブ化で追加する i18n キー（Issue #229 / TDD 先行）の契約を固定する単体テスト。
+//
+// #229 は次の 2 つを翻訳へ追加する（文言そのものはプロダクト側で自然に調整可）:
+//   - t.blog.lead        : ブログの立ち位置を一言添える文（PageFace に配置）
+//   - t.blog.channels    : { heading, zenn, note } の外部チャンネル導線の文言
+// 型 Translations は ja/en 双方に同一 shape を要求するため片側更新は型エラーになるが、
+// 本テストは「両ロケールでキーが揃い、値が非空文字列である」ことを実行時に明示的に固定する
+// （片側更新・空プレースホルダの防止）。既存 translations.test.ts と同じ流儀で書く。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は blog.lead / blog.channels 未追加のため RED、実装後に GREEN。
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { translations } from './translations'
+import type { Locale } from './types'
+
+const LOCALES: Locale[] = ['ja', 'en']
+const CHANNEL_KEYS = ['heading', 'zenn', 'note'] as const
+
+for (const locale of LOCALES) {
+  test(`translations[${locale}]: blog.lead が非空文字列である`, () => {
+    // Given: 当該ロケールの blog ブロック
+    const lead = translations[locale].blog.lead
+    // Then: 立ち位置の一文が非空の文字列で定義されている
+    assert.equal(typeof lead, 'string')
+    assert.ok(lead.length > 0, `blog.lead が空文字（${locale}）`)
+  })
+
+  test(`translations[${locale}]: blog.channels ブロックが存在する`, () => {
+    // Given/When/Then: 外部チャンネル導線の文言ブロックが定義されている
+    assert.ok(
+      translations[locale].blog.channels,
+      `translations.${locale}.blog.channels が未定義`,
+    )
+  })
+
+  for (const key of CHANNEL_KEYS) {
+    test(`translations[${locale}]: blog.channels.${key} が非空文字列である`, () => {
+      // Given: 当該ロケールの channels ブロック
+      const value = translations[locale].blog.channels[key]
+      // Then: 非空の文字列である（プレースホルダや欠落を許さない）
+      assert.equal(typeof value, 'string')
+      assert.ok(value.length > 0, `blog.channels.${key} が空文字（${locale}）`)
+    })
+  }
+}
+
+test('translations: blog.channels のキー集合が ja/en で一致する', () => {
+  // Given: 両ロケールの channels ブロック
+  const jaKeys = Object.keys(translations.ja.blog.channels).sort()
+  const enKeys = Object.keys(translations.en.blog.channels).sort()
+  // Then: キー集合が完全一致する（片側だけにキーがある状態を検出）
+  assert.deepEqual(jaKeys, enKeys)
+})
+
+test('translations: 既存の blog.title / blog.all は維持される（回帰防止）', () => {
+  // Given/When/Then: ハブ化の追加で既存キーを壊さない
+  for (const locale of LOCALES) {
+    assert.ok(
+      translations[locale].blog.title.length > 0,
+      `blog.title が空（${locale}）`,
+    )
+    assert.ok(
+      translations[locale].blog.all.length > 0,
+      `blog.all が空（${locale}）`,
+    )
+  }
+})

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -198,6 +198,12 @@ export const translations: Translations = {
       title: 'ブログ',
       all: 'すべて',
       findOutMore: 'もっと見る',
+      lead: '日々の考えごとや暮らしの記録。技術の話は Zenn、ラフな雑記は note に書いています。',
+      channels: {
+        heading: '他の場所でも書いています',
+        zenn: '技術記事は Zenn へ',
+        note: 'ラフな雑記は note へ',
+      },
     },
     announcements: {
       title: 'News',
@@ -447,6 +453,12 @@ export const translations: Translations = {
       title: 'Blog',
       all: 'All',
       findOutMore: 'Find Out More',
+      lead: 'Notes on everyday thoughts and daily life. I write about tech on Zenn and casual jottings on note.',
+      channels: {
+        heading: 'I also write in other places',
+        zenn: 'Tech articles on Zenn',
+        note: 'Casual notes on note',
+      },
     },
     announcements: {
       title: 'News',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -139,6 +139,12 @@ export type TranslationKeys = {
     title: string
     all: string
     findOutMore: string
+    lead: string
+    channels: {
+      heading: string
+      zenn: string
+      note: string
+    }
   }
   announcements: {
     title: string


### PR DESCRIPTION
## 概要
GitHub Issue #229「ブログをハブ化: Zenn / note チャンネルカードの常設＋立ち位置の明文化」を takt（default workflow: テスト先行）で実装。

## 背景

発信チャンネルを「my_site ブログ=エッセイ・人生の記録（正本）／技術=Zenn／ラフな雑記=note」に書き分ける方針にした（CEO決定 2026-07-02）。my_site のブログページを**発信のハブ**とし、Zenn / note への導線を常設する。

前提: #223〜#228 マージ済み（フッターの `src/config/links.ts` にURL定数がある想定。無ければ本イシューで作成）。

## 変更内容

### 1. チャンネルカードの常設（`src/app/components/templates/ArticleList.tsx` 周辺）
- ブログ index（/blog）の記事一覧の**上**に、「他の場所でも書いています」枠として Zenn / note の2カードを横並び（モバイルは縦積み）で常設
  - **Zenn**: https://zenn.dev/motoshifurugen — ラベル例「技術記事は Zenn へ」
  - **note**: https://note.com/cocoa_hearts21 — ラベル例「ラフな雑記は note へ」
- 見た目は BlogCard とトーンを揃えつつ、外部リンクだと分かる控えめなカード（サービス名アイコン＋一言＋外部リンクアイコン）。記事一覧より主張しないこと
- `target="_blank" rel="noopener noreferrer"`。URL は `src/config/links.ts` の定数を参照

### 2. ブログの立ち位置の明文化
- ブログ index の `PageFace`（現在 subtitle/mainMessage が空）に一言添える。例:「日々の考えごとや暮らしの記録。技術の話は Zenn、ラフな雑記は note に書いています。」（文言は自然に調整可）

### 3. やらないこと
- 記事の移行・削除はしない（既存MDX記事はすべてそのまま）
- Zenn/note の記事一覧をAPIで取り込むことはしない（リンク導線のみ。RSS取り込みは将来検討）

## 完了条件
- `npm run build` 成功、`npm run lint` パス
- /blog 上部に Zenn / note カードが表示され、新規タブで正しいプロフィールへ飛ぶ（ライト/ダーク両対応）
- 記事一覧・タグフィルタ・いいね等の既存機能に影響がない

---
Workflow `default` completed successfully.

Closes #229

🤖 Generated with takt + Claude Code