### PR TITLE
[#233] UI刷新(9): News オレンジチップがライト背景で読めない（コントラスト修正＋orangeスケール追加）

### DIFF
--- a/src/app/components/organisms/MessageBoard.contrast.test.tsx
+++ b/src/app/components/organisms/MessageBoard.contrast.test.tsx
@@ -1,0 +1,121 @@
+// MessageBoard notification チップのコントラスト修正契約を固定する単体テスト
+// （Issue #233 UI刷新 9 / TDD 先行）。
+//
+// notification チップは半透明 bg-orange/10 text-orange のため、ライトモード・空色背景
+// （sky-mobile）＋ bg-white/15 ラッパーの二重透過で文字コントラストが約 1.1:1 に潰れていた。
+// 修正は blogUpdate（teal バッジ）と同型の「不透明淡色地＋濃色文字」へ:
+//   ライト: bg-orange-50 text-orange-800
+//   ダーク: dark:bg-night-orange/20 dark:text-night-orange（約 5.1:1 で AA 合格・維持）
+// あわせて日付/バッジの arbitrary 値（min-w-[80px] / min-w-[120px]）を整理する。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は bg-orange/10 text-orange と min-w-[...] のため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { I18nProvider } from '../../../i18n/context'
+import { translations } from '../../../i18n/translations'
+import MessageBoard from './MessageBoard'
+;(globalThis as Record<string, unknown>).React = React
+
+function renderBoard(locale: 'ja' | 'en'): string {
+  return renderToStaticMarkup(
+    <I18nProvider initialLocale={locale}>
+      <MessageBoard />
+    </I18nProvider>,
+  )
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+// カテゴリ名を内包するバッジ <span> の class 属性を取り出す。
+function badgeClassForCategory(html: string, categoryText: string): string {
+  const match = html.match(
+    new RegExp(
+      '<span class="([^"]*)"[^>]*>' + escapeRegExp(categoryText) + '</span>',
+    ),
+  )
+  assert.ok(match, `カテゴリ「${categoryText}」のバッジ span が存在する`)
+  return match![1]
+}
+
+function notificationBadge(html: string): string {
+  return badgeClassForCategory(
+    html,
+    translations.ja.announcements.categories.notification,
+  )
+}
+
+test('notification: ライト地を不透明淡色 bg-orange-50 で塗る', () => {
+  // Given/When: お知らせ欄を描画する
+  const badge = notificationBadge(renderBoard('ja'))
+  // Then: 空色背景が透けない不透明淡色地になっている
+  assert.match(badge, /\bbg-orange-50\b/, 'bg-orange-50 を含む')
+})
+
+test('notification: 文字を濃色 text-orange-800 にする', () => {
+  // Given/When: お知らせ欄を描画する
+  const badge = notificationBadge(renderBoard('ja'))
+  // Then: 淡地に対して十分濃い文字色になっている
+  assert.match(badge, /\btext-orange-800\b/, 'text-orange-800 を含む')
+})
+
+test('notification: 半透明ライト地 bg-orange/xx（根本原因）を残さない', () => {
+  // Given/When: お知らせ欄を描画する
+  const badge = notificationBadge(renderBoard('ja'))
+  // Then: 空色が透ける半透明ライト地（bg-orange/10 等）が消えている。
+  //       ダークの bg-night-orange/20 は "bg-orange/" に一致しないため影響しない。
+  assert.ok(!/bg-orange\/\d/.test(badge), 'bg-orange/xx を含まない')
+})
+
+test('notification: ダークモード配色（night-orange）を維持する', () => {
+  // Given/When: お知らせ欄を描画する
+  const badge = notificationBadge(renderBoard('ja'))
+  // Then: AA 合格済みのダーク配色は変更しない
+  assert.match(
+    badge,
+    /dark:bg-night-orange\/20/,
+    'dark:bg-night-orange/20 を維持',
+  )
+  assert.match(
+    badge,
+    /dark:text-night-orange\b/,
+    'dark:text-night-orange を維持',
+  )
+})
+
+test('notification: バッジは丸ピル型（rounded-full）を維持する', () => {
+  // Given/When: お知らせ欄を描画する
+  const badge = notificationBadge(renderBoard('ja'))
+  // Then: 配色変更でバッジ形状（#224 で導入）は壊さない
+  assert.match(badge, /\brounded-full\b/, 'rounded-full を維持')
+})
+
+test('notification: blogUpdate（teal バッジ）は変更しない（リグレッション防止）', () => {
+  // Given/When: お知らせ欄を描画する
+  const badge = badgeClassForCategory(
+    renderBoard('ja'),
+    translations.ja.announcements.categories.blogUpdate,
+  )
+  // Then: teal 側は本 Issue の対象外。既存の淡色地＋濃色文字を維持する
+  assert.match(badge, /\bbg-teal-50\b/, 'bg-teal-50 を維持')
+  assert.match(badge, /\btext-teal-700\b/, 'text-teal-700 を維持')
+})
+
+test('MessageBoard: 日付・バッジの arbitrary min-w（min-w-[...]）を撤去する', () => {
+  // Given/When: お知らせ欄を描画する
+  const html = renderBoard('ja')
+  // Then: min-w-[80px] / min-w-[120px] の arbitrary 値が消えている
+  assert.ok(!/min-w-\[/.test(html), 'min-w-[...] を含まない')
+})
+
+test('MessageBoard: 日付列は spacing scale の固定幅 min-w-20 を保つ', () => {
+  // Given/When: お知らせ欄を描画する
+  const html = renderBoard('ja')
+  // Then: 日付の桁揃え用固定幅（80px=min-w-20）は scale トークンで維持する
+  assert.match(html, /\bmin-w-20\b/, 'min-w-20 を含む')
+})

--- a/src/app/components/organisms/MessageBoard.tsx
+++ b/src/app/components/organisms/MessageBoard.tsx
@@ -9,23 +9,23 @@ const categoryBadgeClasses: Record<AnnouncementData['categoryKey'], string> = {
   blogUpdate:
     'bg-teal-50 text-teal-700 dark:bg-teal-900/40 dark:text-night-teal',
   notification:
-    'bg-orange/10 text-orange dark:bg-night-orange/20 dark:text-night-orange',
+    'bg-orange-50 text-orange-800 dark:bg-night-orange/20 dark:text-night-orange',
 }
 
 const MessageBoard = () => {
   const { t } = useI18n()
 
   return (
-    <div className="my-20 rounded-md bg-white/15 px-4 py-4 dark:bg-night-black/50">
+    <div className="my-20 rounded-md bg-white/15 p-4 dark:bg-night-black/50">
       <h3 className="mb-2 select-none">{t.announcements.title}</h3>
       <ul className="m-0 list-none p-0">
         {announcementsData.map((announcement, index) => (
           <li key={index}>
             <div className="flex select-none flex-wrap items-center gap-x-4 gap-y-1 rounded-md p-4 text-main-black transition-colors hover:bg-main-black/5 dark:text-night-white dark:hover:bg-night-white/5 md:flex-nowrap">
-              <p className="m-0 min-w-[80px] text-xs tabular-nums text-main-black/60 dark:text-night-white/60">
+              <p className="m-0 min-w-20 text-xs tabular-nums text-main-black/60 dark:text-night-white/60">
                 {announcement.date}
               </p>
-              <p className="m-0 min-w-[120px] text-center">
+              <p className="m-0">
                 <span
                   className={`inline-block rounded-full px-3 py-1 text-center text-xs font-medium leading-none ${categoryBadgeClasses[announcement.categoryKey]}`}
                 >

--- a/src/app/typography-spacing-scale.test.ts
+++ b/src/app/typography-spacing-scale.test.ts
@@ -135,11 +135,21 @@ test('ArticleContent: ブログ本文カードのモバイル p-2 を p-5 へ引
   assert.ok(!hasBareClass(source, 'p-2'), 'p-2 を含まない')
 })
 
-test('MessageBoard: top パネルのモバイル px-2 を px-4 へ引き上げる', () => {
+test('MessageBoard: top パネルのモバイル padding を 16px（p-4）以上に保つ', () => {
   // Given/When: top ページのお知らせパネルを読む
   const source = read('components/organisms/MessageBoard.tsx')
-  // Then: モバイルの横 padding は px-4（16px）以上にする
-  assert.ok(hasBareClass(source, 'px-4'), 'px-4 を含む')
-  // Then: 窮屈な px-2（8px）は残さない
+  // Then: モバイルの内側 padding は 16px 以上にする（p-4 は px-4 を内包する等価表記）
+  assert.ok(hasBareClass(source, 'p-4'), 'p-4 を含む')
+  // Then: 窮屈な px-2 / p-2（8px）は残さない
   assert.ok(!hasBareClass(source, 'px-2'), 'px-2 を含まない')
+  assert.ok(!hasBareClass(source, 'p-2'), 'p-2 を含まない')
+})
+
+test('MessageBoard: 縦横同値 padding は冗長な px-4 py-4 でなく p-4 に短縮する', () => {
+  // Given/When: top ページのお知らせパネルを読む
+  const source = read('components/organisms/MessageBoard.tsx')
+  // Then: eslint tailwindcss/enforces-shorthand を誘発する冗長表記を残さない
+  //       （px-N py-N が同値なら shorthand p-N に統一する）
+  assert.ok(!source.includes('px-4 py-4'), 'px-4 py-4 の冗長表記を含まない')
+  assert.ok(!source.includes('py-4 px-4'), 'py-4 px-4 の冗長表記を含まない')
 })

--- a/src/tailwind.config.orange.test.ts
+++ b/src/tailwind.config.orange.test.ts
@@ -1,0 +1,91 @@
+// orange カラースケール新設（Issue #233 UI刷新 9 / TDD 先行）の契約を固定する単体テスト。
+//
+// News（お知らせ）の notification チップは、ライトモード・空色背景（sky-mobile）上で
+// 半透明 bg-orange/10 が透けて文字コントラストが約 1.1:1 まで潰れていた。
+// 修正は teal と同型に orange をスケール化し、不透明淡色地 orange-50 ＋濃色文字
+// orange-800 でチップを塗る（DEFAULT は既存 bg-orange/text-orange のため維持）。
+//
+// 本テストは config が公開する「値」に対して契約を固定する:
+//   - orange.DEFAULT を維持（別テスト tailwind.config.test.ts で検証）
+//   - orange.50 / orange.800 が有効な hex で存在する
+//   - orange.50（淡色地）と orange.800（濃色文字）の WCAG コントラスト比が
+//     AA 基準 4.5:1 以上（= 完了条件「ライト空色背景で 4.5:1 以上」の本質）
+// 具体的な淡色/濃色 hex は実装者の裁量に委ねるため、個別値ではなく
+// 「存在」「明暗関係」「コントラスト比」で契約を固定する。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は orange がスカラー値のため RED、実装後に GREEN になることを期待する。
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import config from '../tailwind.config'
+
+const extend = (config.theme as { extend?: Record<string, unknown> }).extend
+
+const getOrange = (): Record<string, string> => {
+  assert.ok(extend, 'theme.extend が定義されている')
+  const colors = extend.colors as Record<string, unknown> | undefined
+  assert.ok(colors, 'theme.extend.colors が定義されている')
+  const orange = colors.orange as Record<string, string> | undefined
+  assert.ok(orange, 'orange が定義されている')
+  return orange
+}
+
+const isHex = (value: unknown): value is string =>
+  typeof value === 'string' && /^#[0-9a-fA-F]{6}$/.test(value)
+
+// --- WCAG 2.x コントラスト計算ヘルパ ---
+// https://www.w3.org/TR/WCAG21/#dfn-contrast-ratio
+function channelLuminance(channel8bit: number): number {
+  const c = channel8bit / 255
+  return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+}
+
+function relativeLuminance(hex: string): number {
+  const r = parseInt(hex.slice(1, 3), 16)
+  const g = parseInt(hex.slice(3, 5), 16)
+  const b = parseInt(hex.slice(5, 7), 16)
+  return (
+    0.2126 * channelLuminance(r) +
+    0.7152 * channelLuminance(g) +
+    0.0722 * channelLuminance(b)
+  )
+}
+
+function contrastRatio(hexA: string, hexB: string): number {
+  const la = relativeLuminance(hexA)
+  const lb = relativeLuminance(hexB)
+  const lighter = Math.max(la, lb)
+  const darker = Math.min(la, lb)
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+test('orange スケール: 不透明淡色地(50)と濃色文字(800)が hex で存在する', () => {
+  // Given/When: スケール化された orange
+  const orange = getOrange()
+  // Then: notification チップの淡地(50)と濃文字(800)が有効な hex で存在する
+  assert.ok(isHex(orange['50']), 'orange.50 が #RRGGBB 形式である')
+  assert.ok(isHex(orange['800']), 'orange.800 が #RRGGBB 形式である')
+})
+
+test('orange: 淡色地(50)は濃色文字(800)より明るい', () => {
+  // Given: 淡地×濃文字のバッジ配色
+  const orange = getOrange()
+  // When/Then: 50 の相対輝度が 800 より高い（淡地×濃文字の関係が成立）
+  assert.ok(
+    relativeLuminance(orange['50']) > relativeLuminance(orange['800']),
+    'orange.50 は orange.800 より明るい',
+  )
+})
+
+test('orange: 文字(800) on 地(50) の WCAG コントラスト比が AA 4.5:1 以上', () => {
+  // Given: 不透明淡色地(50) ＋ 濃色文字(800) のチップ
+  const orange = getOrange()
+  // When: 800 と 50 のコントラスト比を求める
+  const ratio = contrastRatio(orange['800'], orange['50'])
+  // Then: WCAG AA（通常テキスト 4.5:1）を満たす（完了条件そのもの）
+  assert.ok(
+    ratio >= 4.5,
+    `コントラスト比 ${ratio.toFixed(2)}:1 が AA 基準 4.5:1 以上である`,
+  )
+})

--- a/src/tailwind.config.test.ts
+++ b/src/tailwind.config.test.ts
@@ -44,15 +44,22 @@ test('teal.DEFAULT: CSS標準色 teal(#008080) から差し替えられている
   )
 })
 
-test('orange: CSS標準色 darkorange(#FF8C00) から柔らかいアンバーへ差し替えられている', () => {
-  // Given/When: config の orange（スカラー値）
-  const orange = getColors().orange
-  // Then: #FF8C00 ではない有効な hex
-  assert.ok(isHex(orange), 'orange が #RRGGBB 形式である')
+test('orange.DEFAULT: darkorange(#FF8C00) ではなく既存アンバー(#F59E0B)を維持する', () => {
+  // Given/When: config の orange（Issue #233 でスケール化されたオブジェクト）
+  const orange = getColors().orange as Record<string, string>
+  // Then: DEFAULT は bg-orange / text-orange（Tags 等）の解決先。
+  //       スケール化しても既存利用箇所を無影響に保つため #F59E0B を維持する。
+  assert.ok(orange, 'orange が定義されている')
+  assert.ok(isHex(orange.DEFAULT), 'orange.DEFAULT が #RRGGBB 形式である')
   assert.notEqual(
-    (orange as string).toLowerCase(),
+    orange.DEFAULT.toLowerCase(),
     '#ff8c00',
-    'orange は darkorange ではない',
+    'orange.DEFAULT は darkorange ではない',
+  )
+  assert.equal(
+    orange.DEFAULT.toUpperCase(),
+    '#F59E0B',
+    'orange.DEFAULT は既存値 #F59E0B を維持する',
   )
 })
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -35,7 +35,11 @@ const config: Config = {
           800: '#08453F',
           900: '#06332E',
         },
-        orange: '#F59E0B',
+        orange: {
+          DEFAULT: '#F59E0B',
+          50: '#FEF3C7',
+          800: '#92400E',
+        },
       },
       animation: {
         'fade-in': 'fadeIn 10s ease-in-out',


### PR DESCRIPTION
## 概要
GitHub Issue #233「UI刷新(9): News オレンジチップがライト背景で読めない（コントラスト修正＋orangeスケール追加）」を takt（default workflow: テスト先行）で実装。

## 背景

トップページ News（お知らせ）のオレンジ色カテゴリチップが、**ライトモードで背景に潰れて文字がほぼ見えない**（CEO報告 2026-07-02）。

監査結果（origin/main、#224/PR#231 マージ後のコード）:

- 該当: `src/app/components/organisms/MessageBoard.tsx` の `notification` チップ = `bg-orange/10 text-orange dark:bg-night-orange/20 dark:text-night-orange`
- トップページのライト背景は solid の空色（`bg-sky-mobile` ≈ rgb(134,179,224)）。その上に `bg-white/15` のラッパー、さらに `bg-orange/10` と**半透明が二重に重なり**、チップの実効背景はくすんだ水色になる
- 結果、文字 `#F59E0B` とのコントラスト比 **約 1.1:1**（WCAG AA 4.5:1 に対しほぼゼロ）
- 根本原因: `tailwind.config.ts` の `orange` が単一値（`#F59E0B`）でスケールがなく、teal のように不透明な淡色（`teal-50`）が使えなかったため半透明で誤魔化されている
- ダークモード側は約 5.1:1 で AA 合格しており**変更不要**

## 変更内容

### 1. orange カラースケールの追加（tailwind.config.ts）

teal と同様に orange をスケール化する（既存の `bg-orange`/`text-orange` 利用箇所は DEFAULT 維持で無影響）:

```ts
orange: { DEFAULT: '#F59E0B', 50: '#FEF3C7', 800: '#92400E' }
```

### 2. notification チップの配色変更（ライトのみ）

teal バッジ（`bg-teal-50 text-teal-700`）と同型の「**不透明**淡色地＋濃色文字」へ:

```
bg-orange-50 text-orange-800 dark:bg-night-orange/20 dark:text-night-orange
```

→ #92400E on #FEF3C7 ≈ 6.4:1 で AA 合格。背景を不透明にすることで空色が透けなくなる点が本質。

※ 塗りチップ＋白文字（`bg-orange text-white`）は 2.15:1 で AA 落ちのため不採用。

### 3. 同ファイルのモバイル余白（ついで修正）

- ラッパー `my-20 rounded-md bg-white/15 px-2 py-4` の非対称を解消し `p-4` 基調に（li 側 padding との合計が過剰なら li を調整）
- 日付 `min-w-[80px]` / バッジ `min-w-[120px] text-center` の arbitrary 値を整理。特にバッジの `min-w-[120px]` は左揃えレイアウトと不整合な空白を作るため撤去（幅は内容なり）

## 完了条件

- `npm run build` 成功、`npm run lint` パス
- ライトモード・空色背景上で notification チップの文字コントラストが 4.5:1 以上
- ダークモードの見た目は現状維持
- teal（ブログ更新）チップと並べたときトーンが揃っている

---
Workflow `default` completed successfully.

Closes #233

🤖 Generated with takt + Claude Code