### PR TITLE
[#232] UI刷新(8): 記事本文のモバイル可読性（カード内余白と効いていない行間の修正）

### DIFF
--- a/src/app/components/templates/ArticleContent.module.css
+++ b/src/app/components/templates/ArticleContent.module.css
@@ -34,7 +34,7 @@
 /* ------------------------- */
 /* 文字関係 */
 /* ------------------------- */
-.articleContent p {
+.articleParagraph {
   margin: 16px 0;
   font-size: 16px;
   line-height: 1.9;

--- a/src/app/components/templates/ArticleContent.tsx
+++ b/src/app/components/templates/ArticleContent.tsx
@@ -54,7 +54,7 @@ const codeBlockComponents = {
     return <div {...props} />
   },
   p: (props: JSX.IntrinsicAttributes & { children?: ReactNode }) => (
-    <div {...props} />
+    <div {...props} className={styles.articleParagraph} />
   ),
   a: (
     props: JSX.IntrinsicAttributes & { href?: string; children?: ReactNode },
@@ -74,7 +74,7 @@ const ArticleContent: React.FC<ArticleContentProps> = ({
   return (
     <div className="mb-10 flex min-h-screen w-full max-w-screen-lg justify-start md:max-w-full">
       <div
-        className={`w-full max-w-full rounded-lg bg-white p-5 pb-24 text-main-black shadow-card dark:bg-night-gray dark:text-night-white md:p-10 xl:px-[4em] ${styles.articleContent}`}
+        className={`w-full max-w-full rounded-lg bg-white p-6 pb-12 text-main-black shadow-card dark:bg-night-gray dark:text-night-white md:p-10 xl:px-16 ${styles.articleContent}`}
       >
         <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
           <p className="text-main-black dark:text-night-white">

--- a/src/app/components/templates/ArticleContent.wiring.test.ts
+++ b/src/app/components/templates/ArticleContent.wiring.test.ts
@@ -1,0 +1,153 @@
+// 記事本文のモバイル可読性修正（Issue #232 / TDD 先行）を固定する回帰テスト。
+//
+// #232 は記事本文まわりの 2 つの独立した問題を修正する:
+//   (1) 本文カードの内側余白 — モバイルの左右上を 20〜24px 帯へ、極端に非対称な
+//       下余白 pb-24（96px）を pb-12（48px）へ、arbitrary 値 xl:px-[4em] を最寄りの
+//       Tailwind トークン xl:px-16 へ置換する。desktop（md:p-10）は不変に保つ。
+//   (2) 行間・段落間隔が効いていない p→div 置換バグ — codeBlockComponents が MDX の
+//       p を <div> へ置換しているため、.articleContent p のスタイルが本文段落に一切
+//       適用されていない（実効 line-height ~1.5・段落 margin 0）。置換 div へ専用クラス
+//       styles.articleParagraph を付与し、module CSS 側で line-height（≥1.7）＋段落
+//       margin を実効化する。あわせて死んだ .articleContent p を段落クラスへ一本化する。
+//
+// ArticleContent は MDXRemote（next-mdx-remote/rsc, async Server Component）を含むため
+// renderToStaticMarkup で同期描画できず、CSS Module もテストでは {} にモックされ
+// styles.articleParagraph が空になる。よって markup 経由の検証は不可能で、
+// ArticleList.wiring.test.ts / font-noto-sans-wiring.test.ts と同じくソースの静的検査で
+// 契約を固定する。トークン（p-6/pb-12/xl:px-16/styles.articleParagraph/line-height 等）は
+// Prettier 整形で安定するため、空白差異に依存しない構造契約として扱う。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は p-5/pb-24/xl:px-[4em]・articleParagraph 未配線のため RED、実装後に GREEN。
+
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+const tsx = readFileSync(
+  new URL('./ArticleContent.tsx', import.meta.url),
+  'utf8',
+)
+const css = readFileSync(
+  new URL('./ArticleContent.module.css', import.meta.url),
+  'utf8',
+)
+
+// 本文カード div の className（${styles.articleContent} を含む唯一の template literal）を抽出する。
+// これに絞ることで、コードブロック等の無関係な className への誤検出を避ける。
+function cardClassName(source: string): string {
+  const match = source.match(
+    /className=\{`([^`]*\$\{styles\.articleContent\}[^`]*)`\}/,
+  )
+  assert.ok(
+    match,
+    '本文カード div の className（styles.articleContent を含む）が抽出できる',
+  )
+  return match![1]
+}
+
+// CSS ルールのブレース内本文を抽出する（このモジュールはネストしたブレースを持たない単純ルールのみ）。
+function ruleBody(source: string, selector: string): string | null {
+  const idx = source.indexOf(selector)
+  if (idx < 0) return null
+  const open = source.indexOf('{', idx)
+  const close = source.indexOf('}', open)
+  if (open < 0 || close < 0) return null
+  return source.slice(open + 1, close)
+}
+
+// --- (1) 本文カードの内側余白 ---
+
+test('ArticleContent: モバイルの内側余白を p-6（24px, 20〜24px 帯）にする', () => {
+  // Given: 本文カード div の className
+  const card = cardClassName(tsx)
+  // Then: モバイル余白が p-6（24px, 受入基準 20px 以上）である
+  assert.match(card, /(?<![\w-])p-6(?![\w-])/, 'p-6 を含む')
+})
+
+test('ArticleContent: 旧モバイル余白 p-5 / p-2 を残さない', () => {
+  // Given: 本文カード div の className
+  const card = cardClassName(tsx)
+  // Then: 窮屈だった / 中途半端だった旧値は残っていない
+  assert.ok(!/(?<![\w-])p-5(?![\w-])/.test(card), 'p-5 を含まない')
+  assert.ok(!/(?<![\w-])p-2(?![\w-])/.test(card), 'p-2 を含まない')
+})
+
+test('ArticleContent: 極端に非対称な下余白 pb-24 を pb-12 へ緩和する', () => {
+  // Given: 本文カード div の className
+  const card = cardClassName(tsx)
+  // Then: pb-12（48px）へ縮小し、pb-24（96px）は残っていない
+  assert.match(card, /(?<![\w-])pb-12(?![\w-])/, 'pb-12 を含む')
+  assert.ok(!/(?<![\w-])pb-24(?![\w-])/.test(card), 'pb-24 を含まない')
+})
+
+test('ArticleContent: arbitrary 値 xl:px-[4em] を Tailwind トークン xl:px-16 へ置換する', () => {
+  // Given: 本文カード div の className
+  const card = cardClassName(tsx)
+  // Then: 標準トークン xl:px-16（=4rem=64px, 旧 4em と同値）へ置換し arbitrary 値は残さない
+  assert.match(card, /(?<![\w-])xl:px-16(?![\w-])/, 'xl:px-16 を含む')
+  assert.ok(!card.includes('xl:px-[4em]'), 'xl:px-[4em] を含まない')
+})
+
+test('ArticleContent: desktop 余白 md:p-10 を不変に保つ（世界観・レイアウト維持）', () => {
+  // Given: 本文カード div の className
+  const card = cardClassName(tsx)
+  // Then: md 以上の余白は据え置き（desktop の見た目を変えない制約）
+  assert.match(card, /(?<![\w-])md:p-10(?![\w-])/, 'md:p-10 を含む')
+})
+
+// --- (2) 行間・段落間隔の実効化（p→div 置換バグの修正） ---
+
+test('ArticleContent: 置換 div（本文段落）へ段落クラス styles.articleParagraph を配線する', () => {
+  // Given/When: p→div 置換で本文段落は <div> になる
+  // Then: その div に styles.articleParagraph を付与し、実レンダリング要素へスタイルを効かせる
+  assert.ok(
+    tsx.includes('styles.articleParagraph'),
+    'styles.articleParagraph を参照して段落 div に付与する',
+  )
+})
+
+test('ArticleContent.module.css: 段落クラス .articleParagraph を定義する', () => {
+  // Given/When/Then: 実レンダリング要素向けの段落ルールが存在する
+  assert.ok(
+    ruleBody(css, '.articleParagraph') !== null,
+    '.articleParagraph ルールが存在する',
+  )
+})
+
+test('ArticleContent.module.css: 段落の line-height を 1.7 以上にする', () => {
+  // Given: .articleParagraph ルール本文
+  const body = ruleBody(css, '.articleParagraph')
+  assert.ok(body, '.articleParagraph ルールが存在する')
+  // When: line-height の値を取り出す
+  const m = body!.match(/line-height:\s*([\d.]+)/)
+  assert.ok(m, 'line-height 宣言が存在する')
+  // Then: 受入基準どおり 1.7 以上（黒い塊回避の行間）
+  assert.ok(
+    parseFloat(m![1]) >= 1.7,
+    `line-height は 1.7 以上（実際: ${m![1]}）`,
+  )
+})
+
+test('ArticleContent.module.css: 段落間に正の縦マージンを設定する', () => {
+  // Given: .articleParagraph ルール本文
+  const body = ruleBody(css, '.articleParagraph')
+  assert.ok(body, '.articleParagraph ルールが存在する')
+  // When: 縦方向の margin 宣言を取り出す（shorthand の第一値 or margin-top/-bottom/-block）
+  const m = body!.match(/margin(?:-top|-bottom|-block)?:\s*([\d.]+)(px|rem|em)/)
+  assert.ok(m, 'margin 宣言が存在する')
+  // Then: 段落間マージンが正の値で適用される
+  assert.ok(
+    parseFloat(m![1]) > 0,
+    `段落マージンは正の値（実際: ${m![1]}${m![2]}）`,
+  )
+})
+
+test('ArticleContent.module.css: 死んだ .articleContent p を段落クラスへ一本化する', () => {
+  // Given/When/Then: p→div 化で無効だった .articleContent p を撤去し、
+  // 本文タイポを .articleParagraph 側へ一本化する（二重管理の解消）
+  assert.ok(
+    !/\.articleContent\s+p\s*\{/.test(css),
+    '無効な .articleContent p セレクタを残さない',
+  )
+})

--- a/src/app/typography-spacing-scale.test.ts
+++ b/src/app/typography-spacing-scale.test.ts
@@ -126,13 +126,14 @@ test('BlogGrid: 詰まった gap-6 を残さない', () => {
 // カード・パネルのモバイル内側 padding を p-5/px-4 下限へ引き上げ、
 // 文字が枠に接近する p-2/px-2（8px）を残さない。
 // ------------------------------------------------------------------
-test('ArticleContent: ブログ本文カードのモバイル p-2 を p-5 へ引き上げる', () => {
+test('ArticleContent: ブログ本文カードのモバイル p-2 を p-6 へ引き上げる', () => {
   // Given/When: 記事本文テンプレートを読む
   const source = read('components/templates/ArticleContent.tsx')
-  // Then: モバイルの内側 padding は p-5（20px）以上にする
-  assert.ok(hasBareClass(source, 'p-5'), 'p-5 を含む')
-  // Then: 窮屈な p-2（8px）は残さない（pb-24/md:p-10 は別クラスのため影響なし）
+  // Then: モバイルの内側 padding は p-6（24px, 20px 以上）にする（#232 で p-5→p-6 へ再引き上げ）
+  assert.ok(hasBareClass(source, 'p-6'), 'p-6 を含む')
+  // Then: 窮屈な p-2（8px）・中途半端な p-5 は残さない（md:p-10 は別クラスのため影響なし）
   assert.ok(!hasBareClass(source, 'p-2'), 'p-2 を含まない')
+  assert.ok(!hasBareClass(source, 'p-5'), 'p-5 を含まない')
 })
 
 test('MessageBoard: top パネルのモバイル padding を 16px（p-4）以上に保つ', () => {


### PR DESCRIPTION
## 概要
GitHub Issue #232「UI刷新(8): 記事本文のモバイル可読性（カード内余白と効いていない行間の修正）」を takt（default workflow: テスト先行）で実装。

## 背景

UI刷新(#223〜#229)の余白整理後も、**ブログ記事ページがスマホで見づらい**とCEOレビューで指摘。監査の結果、記事本文まわりに2つの独立した問題があることが判明した。読み物ページはサイトの一等地であり、影響が最も大きい。

余白設計の判断基準: 8pxグリッド（余白は8の倍数基調）／近接の法則（関連は狭く・無関係は広く）／本文の行間は 1.7〜1.9 目安。

前提: #226（タイポ・余白統一）マージ済みであること。#226 のスケール・トークンに合わせる。

## 変更内容

### 1. 記事本文カードの内側余白（モバイル 8px → 20〜24px）

`src/app/components/templates/ArticleContent.tsx` の本文カード div が `p-2 pb-24 ... md:p-10 xl:px-[4em]`。

- モバイルで本文がカード枠から **8px** しか離れず窮屈。`p-5`〜`p-6`（20〜24px）へ
- 下だけ `pb-24`（96px）と極端に非対称。`pb-12` 程度へ縮める
- `xl:px-[4em]` の arbitrary 値は最寄りの Tailwind トークンへ置換（#226 の方針に合わせる）

### 2. 記事本文の行間・段落間隔が実は効いていない（p→div 置換バグ）

`ArticleContent.tsx` の `codeBlockComponents` が MDX の `p` を `<div>` に置換しているため、`ArticleContent.module.css` の `.articleContent p { font-size:16px; line-height:1.9; margin:16px 0 }` が**本文段落に一切適用されていない**（実効値: line-height 1.5・段落マージン0）。テキストが黒い塊に見える直接原因。

- 置換 div にクラスを付与して `line-height: 1.8` 前後＋段落間 `margin` を明示的に当てる、またはセレクタを `.articleContent :where(p, div)` 系に広げるなど、**実際にレンダリングされる要素に行間・段落間隔が効く**ように修正
- あわせて記事本文のタイポグラフィ指定が `ArticleContent.module.css` と `globals.css` に二重管理されている状態を `.articleContent` 側へ一本化する

## 完了条件

- `npm run build` 成功、`npm run lint` パス
- モバイル幅（375px 想定）で記事本文がカード枠から 20px 以上離れている
- 実際にレンダリングされた記事本文の段落に line-height 1.7 以上と段落間マージンが適用されている（DevTools の computed style で確認できる状態）
- 記事の見た目の世界観・レイアウト構造は変えない

---
Workflow `default` completed successfully.

Closes #232

🤖 Generated with takt + Claude Code