### PR TITLE
[#240] UI刷新(10): ヘッダー/モバイルメニュー3点（GitHubリンクの誤反転・タップ状態の残留・背景の透明度）

### DIFF
--- a/src/app/components/molecules/GithubLinkButton.groupScope.test.tsx
+++ b/src/app/components/molecules/GithubLinkButton.groupScope.test.tsx
@@ -1,0 +1,159 @@
+// GitHub リンクボタン（src/app/components/molecules/GithubLinkButton.tsx）の
+// group スコープ分離と onClick 配線契約を固定する単体テスト
+// （Issue #240 UI刷新 10 / 3点セット / TDD 先行）。
+//
+// 背景（CEOレビュー 2026-07-02）:
+//   1. 誤反転: 自 div の無名 `group` が Header.tsx の nav 無名 `group` と衝突し、
+//      アイコン/ラベルの `group-hover:text-main-white dark:group-hover:text-main-black` が
+//      nav 内どこかの hover で反転する。→ 自 div を名前付き `group/github` にし、
+//      hover variant を `group-hover/github:` へスコープ分離する。
+//      無名 `group-hover:text-main-white`(+dark) を残さないことが誤反転回帰防止の核心。
+//   5. 外部リンク: `target="_blank"` で pathname 不変のため close effect が発火しない。
+//      → onClick prop（`setMenuOpen(false)`）を <Link> へ配線し、タップでメニューを閉じる。
+//
+// renderToStaticMarkup は effect 未実行・関数 prop は素の HTML へ出力しないため、
+// onClick の「実際にメニューを閉じる」挙動は検証不能。ここでは Link へ onClick 関数が
+// 渡る配線契約を、Link モックが typeof を data 属性へ写して固定する（＝プロダクション側で
+// <Link onClick={onClick}> と繋がっているかを機械検証する）。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は無名 group のまま・onClick 未配線のため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+// Link モックは className に加えて onClick の型（function/undefined）を data 属性へ写す。
+// これにより「GithubLinkButton が <Link> へ onClick を渡しているか」を SSR HTML で判定できる。
+const linkMock =
+  'data:text/javascript,' +
+  encodeURIComponent(
+    "export default function Link(props){return React.createElement('a',{href:props.href,className:props.className,style:props.style,target:props.target,rel:props.rel,'data-onclick':typeof props.onClick},props.children)}",
+  )
+
+const resolveHook = `
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.endsWith('.css')) {
+    return { url: 'data:text/javascript,export default {}', shortCircuit: true }
+  }
+  if (specifier === 'next/link') {
+    return { url: ${JSON.stringify(linkMock)}, shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}
+`
+register(
+  'data:text/javascript,' + encodeURIComponent(resolveHook),
+  import.meta.url,
+)
+
+// tsx は classic JSX runtime へ変換するため React をグローバルに渡す。
+;(globalThis as Record<string, unknown>).React = React
+
+type GithubLinkButtonComponent = React.FC<{
+  index: number
+  onClick?: () => void
+}>
+
+let GithubLinkButton: GithubLinkButtonComponent
+before(async () => {
+  GithubLinkButton = (await import('./GithubLinkButton'))
+    .default as unknown as GithubLinkButtonComponent
+})
+
+const render = (props: { index: number; onClick?: () => void }): string =>
+  renderToStaticMarkup(<GithubLinkButton {...props} />)
+
+// --- 要件1: group スコープ分離（誤反転の解消） ---
+
+test('GithubLinkButton: 自ボタンを名前付き group/github にする（nav の無名 group と分離）', () => {
+  // Given/When: 描画する
+  const html = render({ index: 5 })
+  // Then: 祖先 nav の無名 group と衝突しない専用スコープを持つ
+  assert.ok(html.includes('group/github'), 'group/github を含む')
+})
+
+test('GithubLinkButton: アイコン/ラベルの hover 反転は group-hover/github: へスコープする（ライト）', () => {
+  // Given/When: 描画する
+  const html = render({ index: 5 })
+  // Then: 自ボタン hover 時のみ白へ反転する
+  assert.ok(
+    html.includes('group-hover/github:text-main-white'),
+    'group-hover/github:text-main-white を含む',
+  )
+})
+
+test('GithubLinkButton: アイコン/ラベルの hover 反転は group-hover/github: へスコープする（ダーク）', () => {
+  // Given/When: 描画する
+  const html = render({ index: 5 })
+  // Then: ダークでも自ボタン hover 限定でスコープする
+  assert.ok(
+    html.includes('dark:group-hover/github:text-main-black'),
+    'dark:group-hover/github:text-main-black を含む',
+  )
+})
+
+test('GithubLinkButton: 無名 group-hover: を残さない（他メニュー hover での誤反転を防ぐ）', () => {
+  // Given/When: 描画する
+  const html = render({ index: 5 })
+  // Then: 祖先の任意 .group:hover にマッチする無名 group-hover: が存在しない
+  //       （`group-hover/github:` は `group-hover:` を部分文字列に含まないため誤検知しない）
+  assert.doesNotMatch(
+    html,
+    /group-hover:text-main-white/,
+    '無名 group-hover:text-main-white を含まない',
+  )
+  assert.doesNotMatch(
+    html,
+    /group-hover:text-main-black/,
+    '無名 group-hover:text-main-black を含まない',
+  )
+})
+
+test('GithubLinkButton: 自ボタン hover の背景/文字反転（hover:bg-main-black 等）は維持する', () => {
+  // Given/When: 描画する
+  const html = render({ index: 5 })
+  // Then: group スコープ分離後も、自ボタン hover の見た目は変えない
+  assert.ok(html.includes('hover:bg-main-black'), 'hover:bg-main-black を含む')
+  assert.ok(
+    html.includes('dark:hover:bg-main-white'),
+    'dark:hover:bg-main-white を含む',
+  )
+})
+
+// --- 要件5: onClick 配線（GitHub タップでメニューを閉じる） ---
+
+test('GithubLinkButton: onClick を渡すと <Link> へ関数として配線される', () => {
+  // Given: メニューを閉じるコールバックを渡す
+  // When: 描画する
+  const html = render({ index: 5, onClick: () => {} })
+  // Then: Link は onClick 関数を受け取る（外部リンクタップ時に setMenuOpen(false) を発火できる）
+  assert.ok(
+    html.includes('data-onclick="function"'),
+    'Link へ onClick が function として渡る',
+  )
+})
+
+test('GithubLinkButton: onClick は optional（未指定でも例外なく描画される）', () => {
+  // Given/When/Then: 既存呼び出し（onClick なし）を後方非互換にしない
+  assert.doesNotThrow(() => render({ index: 5 }))
+  const html = render({ index: 5 })
+  assert.ok(
+    html.includes('data-onclick="undefined"'),
+    'onClick 未指定時は Link へ関数が渡らない',
+  )
+})
+
+test('GithubLinkButton: 外部リンク属性（target=_blank / rel）は維持する', () => {
+  // Given/When: 描画する
+  const html = render({ index: 5 })
+  // Then: 別タブ遷移の契約は変えない（onClick 追加は close 用の副次配線）
+  assert.match(html, /target="_blank"/, 'target="_blank" を維持する')
+  assert.match(
+    html,
+    /rel="noopener noreferrer"/,
+    'rel="noopener noreferrer" を維持する',
+  )
+})

--- a/src/app/components/molecules/GithubLinkButton.tsx
+++ b/src/app/components/molecules/GithubLinkButton.tsx
@@ -7,9 +7,13 @@ import { staggerStyle } from './staggerStyle'
 
 interface GithubLinkButtonProps {
   index: number
+  onClick?: () => void
 }
 
-const GithubLinkButton: React.FC<GithubLinkButtonProps> = ({ index }) => {
+const GithubLinkButton: React.FC<GithubLinkButtonProps> = ({
+  index,
+  onClick,
+}) => {
   return (
     <Link
       className={`mr-auto mt-8 md:mt-0 ${headerMenuItemMotionClass}`}
@@ -17,13 +21,14 @@ const GithubLinkButton: React.FC<GithubLinkButtonProps> = ({ index }) => {
       href="https://github.com/motoshifurugen/my_site"
       target="_blank"
       rel="noopener noreferrer"
+      onClick={onClick}
     >
-      <div className="group flex select-none items-center rounded border border-main-black px-4 py-2 text-main-black hover:bg-main-black hover:text-main-white dark:border-main-white dark:text-night-white dark:hover:bg-main-white dark:hover:text-main-black">
+      <div className="group/github flex select-none items-center rounded border border-main-black px-4 py-2 text-main-black hover:bg-main-black hover:text-main-white dark:border-main-white dark:text-night-white dark:hover:bg-main-white dark:hover:text-main-black">
         <FontAwesomeIcon
           icon={faGithub}
-          className="mr-2 group-hover:text-main-white dark:group-hover:text-main-black"
+          className="mr-2 group-hover/github:text-main-white dark:group-hover/github:text-main-black"
         />
-        <span className="noto-sans-jp bg-transparent text-lg font-bold text-main-black group-hover:text-main-white dark:text-night-white dark:group-hover:text-main-black md:text-base">
+        <span className="noto-sans-jp bg-transparent text-lg font-bold text-main-black group-hover/github:text-main-white dark:text-night-white dark:group-hover/github:text-main-black md:text-base">
           Repository
         </span>
       </div>

--- a/src/app/components/templates/Header.githubClose.test.tsx
+++ b/src/app/components/templates/Header.githubClose.test.tsx
@@ -1,0 +1,93 @@
+// Header（src/app/components/templates/Header.tsx）→ GithubLinkButton → next/link の
+// onClick 伝搬（メニュー閉じ配線）を固定するインテグレーションテスト
+// （Issue #240 UI刷新 10 / 3点セット / 要件5 / TDD 先行）。
+//
+// 背景（CEOレビュー 2026-07-02 #2）:
+//   GitHub リンクは `target="_blank"` で pathname が変わらないため、タップしても
+//   pathname-close effect が発火せずメニューが開いたまま残る。修正は Header が
+//   GithubLinkButton へ onClick（`setMenuOpen(false)`）を渡し、GithubLinkButton が
+//   それを <Link> へ配線して外部リンクタップ時もメニューを閉じること。
+//   ＝ onClick が Header → GithubLinkButton → Link の3モジュールを末端まで伝搬する。
+//
+// renderToStaticMarkup は関数 prop を素の HTML へ出力しないため、Link モックが
+// onClick の型（function/undefined）を data 属性へ写して伝搬を機械検証する。
+// 実際に setMenuOpen(false) が走る挙動は effect 未実行のため範囲外（配線の存在で固定）。
+// usePathname はトップページ相当の '/' を返す（初期 menuOpen=false のまま描画）。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は Header が onClick を渡さない/GithubLinkButton が配線しないため RED、
+// 実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+// Link モックは href に加え onClick の型を data 属性へ写す。
+const linkMock =
+  'data:text/javascript,' +
+  encodeURIComponent(
+    "export default function Link(props){return React.createElement('a',{href:props.href,className:props.className,style:props.style,target:props.target,rel:props.rel,'data-onclick':typeof props.onClick},props.children)}",
+  )
+
+const navMock =
+  'data:text/javascript,' +
+  encodeURIComponent("export function usePathname(){return '/'}")
+
+const resolveHook = `
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.endsWith('.css')) {
+    return { url: 'data:text/javascript,export default {}', shortCircuit: true }
+  }
+  if (specifier === 'next/link') {
+    return { url: ${JSON.stringify(linkMock)}, shortCircuit: true }
+  }
+  if (specifier === 'next/navigation') {
+    return { url: ${JSON.stringify(navMock)}, shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}
+`
+register(
+  'data:text/javascript,' + encodeURIComponent(resolveHook),
+  import.meta.url,
+)
+
+// tsx は classic JSX runtime へ変換するため React をグローバルに渡す。
+;(globalThis as Record<string, unknown>).React = React
+
+let Header: React.FC
+let I18nProvider: React.FC<{ children: React.ReactNode }>
+before(async () => {
+  Header = (await import('./Header')).default as unknown as React.FC
+  I18nProvider = (await import('../../../i18n/context'))
+    .I18nProvider as unknown as React.FC<{ children: React.ReactNode }>
+})
+
+const render = (): string =>
+  renderToStaticMarkup(
+    <I18nProvider>
+      <Header />
+    </I18nProvider>,
+  )
+
+test('Header: GitHub リンクへ onClick（メニュー閉じ）を末端まで伝搬する', () => {
+  // Given/When: ヘッダーを描画する
+  const html = render()
+  // Then: github.com の <a> が onClick 関数を受け取る（Header → GithubLinkButton → Link）
+  assert.match(
+    html,
+    /<a\b[^>]*github\.com[^>]*data-onclick="function"/,
+    'GitHub リンクの Link が onClick を function として受け取る',
+  )
+})
+
+test('Header: onClick 配線は GitHub リンク限定（他メニュー項目には注入しない）', () => {
+  // Given/When: ヘッダーを描画する
+  const html = render()
+  // Then: onClick を受け取る Link はちょうど1つ（＝GitHub のみ）。
+  //       他項目は pathname-close effect で閉じるため onClick 注入は不要。
+  const count = html.split('data-onclick="function"').length - 1
+  assert.equal(count, 1, 'onClick を受け取る Link は GitHub の1つのみ')
+})

--- a/src/app/components/templates/Header.menu.test.tsx
+++ b/src/app/components/templates/Header.menu.test.tsx
@@ -85,41 +85,72 @@ test('Header: 背景に backdrop-blur を用いる', () => {
   assert.ok(html.includes('backdrop-blur-md'), 'backdrop-blur-md を含む')
 })
 
-test('Header: backdrop-filter 対応時はライト背景が半透明（bg-white/70）', () => {
+// 注（Issue #240 UI刷新 10 / 要件4）: 背景をさらに透過させる。
+// backdrop-filter 対応時: ライト bg-white/50・ダーク bg-night-black/50。
+// 非対応フォールバック: ライト bg-white/60・ダーク bg-night-black/60（旧 /90・/70 から引き下げ）。
+// backdrop-blur-md は維持し、可読性を確保する。
+
+test('Header: backdrop-filter 対応時はライト背景がより透過する（bg-white/50）', () => {
   // Given/When: ヘッダーを描画する
   const html = render()
-  // Then: @supports 側で半透明にし後ろを透けさせる
+  // Then: @supports 側で半透明を強め後ろを透けさせる
   assert.ok(
-    html.includes('supports-[backdrop-filter]:bg-white/70'),
-    'supports-[backdrop-filter]:bg-white/70 を含む',
+    html.includes('supports-[backdrop-filter]:bg-white/50'),
+    'supports-[backdrop-filter]:bg-white/50 を含む',
   )
 })
 
-test('Header: backdrop-filter 対応時はダーク背景が半透明（dark:bg-night-black/70）', () => {
+test('Header: backdrop-filter 対応時はダーク背景がより透過する（dark:bg-night-black/50）', () => {
   // Given/When: ヘッダーを描画する
   const html = render()
-  // Then: ダークでも @supports 側で半透明
+  // Then: ダークでも @supports 側で半透明を強める
   assert.ok(
-    html.includes('dark:supports-[backdrop-filter]:bg-night-black/70'),
-    'dark:supports-[backdrop-filter]:bg-night-black/70 を含む',
+    html.includes('dark:supports-[backdrop-filter]:bg-night-black/50'),
+    'dark:supports-[backdrop-filter]:bg-night-black/50 を含む',
   )
 })
 
-test('Header: backdrop-filter 非対応向けに不透明度を上げたフォールバック背景を持つ（ライト）', () => {
+test('Header: backdrop-filter 非対応向けフォールバックもより透過する（ライト bg-white/60）', () => {
   // Given/When: ヘッダーを描画する
   const html = render()
-  // Then: blur が効かない環境でも可読性を確保する不透明寄りの背景
-  assert.ok(html.includes('bg-white/90'), 'bg-white/90 を含む')
+  // Then: blur 非対応環境でも従来より透過（/90 → /60）しつつ可読性を確保する
+  assert.ok(html.includes('bg-white/60'), 'bg-white/60 を含む')
 })
 
-test('Header: backdrop-filter 非対応向けフォールバック背景を持つ（ダーク）', () => {
+test('Header: backdrop-filter 非対応向けフォールバックもより透過する（ダーク dark:bg-night-black/60）', () => {
   // Given/When: ヘッダーを描画する
   const html = render()
-  // Then: ダークでも非対応フォールバックを持つ
+  // Then: ダークでも非対応フォールバックを透過（/90 → /60）させる
   assert.ok(
-    html.includes('dark:bg-night-black/90'),
-    'dark:bg-night-black/90 を含む',
+    html.includes('dark:bg-night-black/60'),
+    'dark:bg-night-black/60 を含む',
   )
+})
+
+test('Header: 旧・重い背景不透明度（/90・/70）は残さない（透過アップの回帰防止）', () => {
+  // Given/When: ヘッダーを描画する
+  const html = render()
+  // Then: 要件4「もっと透明に」を満たすため、旧値へは戻っていない
+  assert.ok(!html.includes('bg-white/90'), 'bg-white/90 を含まない')
+  assert.ok(
+    !html.includes('dark:bg-night-black/90'),
+    'dark:bg-night-black/90 を含まない',
+  )
+  assert.ok(
+    !html.includes('supports-[backdrop-filter]:bg-white/70'),
+    'supports-[backdrop-filter]:bg-white/70 を含まない',
+  )
+  assert.ok(
+    !html.includes('dark:supports-[backdrop-filter]:bg-night-black/70'),
+    'dark:supports-[backdrop-filter]:bg-night-black/70 を含まない',
+  )
+})
+
+test('Header: backdrop-blur-md は維持する（透過を上げても文字可読性を確保）', () => {
+  // Given/When: ヘッダーを描画する
+  const html = render()
+  // Then: blur は残す（要件4の「文字が読める範囲」担保）
+  assert.ok(html.includes('backdrop-blur-md'), 'backdrop-blur-md を含む')
 })
 
 // --- 2. 遷移タイミングの統一（transition-all / 横スライドの廃止） ---

--- a/src/app/components/templates/Header.tsx
+++ b/src/app/components/templates/Header.tsx
@@ -97,9 +97,9 @@ const Header = () => {
             <div
               aria-hidden="true"
               className={`
-              absolute inset-0 -z-10 bg-white/90 backdrop-blur-md transition-opacity duration-200
-              ease-out supports-[backdrop-filter]:bg-white/70
-              dark:bg-night-black/90 dark:supports-[backdrop-filter]:bg-night-black/70
+              absolute inset-0 -z-10 bg-white/60 backdrop-blur-md transition-opacity duration-200
+              ease-out supports-[backdrop-filter]:bg-white/50
+              dark:bg-night-black/60 dark:supports-[backdrop-filter]:bg-night-black/50
               ${menuOpen ? 'opacity-100' : 'opacity-0'}
               motion-reduce:transition-none md:hidden
             `}
@@ -128,7 +128,10 @@ const Header = () => {
             </div>
 
             <div className="ml-auto mt-6 pr-8 md:m-0 md:pr-0">
-              <GithubLinkButton index={links.length + 1} />
+              <GithubLinkButton
+                index={links.length + 1}
+                onClick={() => setMenuOpen(false)}
+              />
             </div>
 
             {/* デスクトップでのテーマ・言語切り替え */}

--- a/src/tailwind.config.hover.test.ts
+++ b/src/tailwind.config.hover.test.ts
@@ -1,0 +1,42 @@
+// tailwind.config.ts の future フラグ契約を固定する単体テスト
+// （Issue #240 UI刷新 10 / 3点セット / 要件2 / TDD 先行）。
+//
+// 背景（CEOレビュー 2026-07-02 #2）:
+//   スマホでメニュータップ後、次ページでもタップしたメニュー名の見た目が残る。
+//   実体の一つは HeaderLinkButton の `hover:opacity-50` がタッチ端末の sticky hover で
+//   タップ後も残ること。指示書の推奨手段は tailwind.config.ts へ
+//   `future: { hoverOnlyWhenSupported: true }` を追加し、全 `hover:` を
+//   `@media (hover: hover)` 化して hover 対応デバイス限定にすること。
+//
+// クラス名（HTML 文字列）は不変のため、契約は config が公開する「値」に対して固定する。
+// CSS 生成結果（@media ラップ）は Tailwind のビルドを要し本テスト範囲外のため、
+// フラグの真偽という single source of truth を検証する。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は future キー未設定のため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import config from '../tailwind.config'
+
+const future = (config as { future?: Record<string, unknown> }).future
+
+test('tailwind config: future.hoverOnlyWhenSupported を有効化する', () => {
+  // Given: config の future フラグ群
+  assert.ok(future, 'config.future が定義されている')
+  // When/Then: hover: が hover 対応デバイス限定になる
+  assert.equal(
+    future.hoverOnlyWhenSupported,
+    true,
+    'future.hoverOnlyWhenSupported === true',
+  )
+})
+
+test('tailwind config: 既存の theme/darkMode 契約は壊さない（future 追加は非破壊）', () => {
+  // Given/When: future 追加後の config
+  // Then: 既存の darkMode='class' と theme.extend.colors は維持される
+  assert.equal(config.darkMode, 'class', "darkMode は 'class' を維持する")
+  const extend = (config.theme as { extend?: Record<string, unknown> }).extend
+  assert.ok(extend, 'theme.extend が維持されている')
+  assert.ok(extend.colors, 'theme.extend.colors が維持されている')
+})

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,6 +2,10 @@ import type { Config } from 'tailwindcss'
 import type { PluginAPI } from 'tailwindcss/types/config'
 
 const config: Config = {
+  // タッチ端末の sticky hover を避けるため、全 `hover:` を @media (hover: hover) 化する（Issue #240）。
+  future: {
+    hoverOnlyWhenSupported: true,
+  },
   darkMode: 'class',
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',


### PR DESCRIPTION
## 概要
GitHub Issue #240「UI刷新(10): ヘッダー/モバイルメニュー3点（GitHubリンクの誤反転・タップ状態の残留・背景の透明度）」を takt（default workflow: テスト先行）で実装。

## 背景（CEOレビュー 2026-07-02 / 3点セット）

### 1. 他メニュー操作で「GitHubリポジトリ」の文字色だけ反転する
- `src/app/components/templates/Header.tsx:88-93` — `<nav>` の className に無名 `group` がある
- `src/app/components/molecules/GithubLinkButton.tsx:21` — ボタン外側 div も `group` を持ち、`:24` のアイコンと `:26` のラベルが `group-hover:text-main-white dark:group-hover:text-main-black` を使っている
- Tailwind の `group-hover:` は**祖先の任意の `.group`:hover** にマッチするため、nav 内のどこか（＝他メニュー項目）を hover/タップして nav が :hover になるだけで GitHub の文字/アイコンが白へ反転する。背景 `hover:bg-main-black` は自ボタン hover 時しか変わらないので「白地に白文字」になり消えたように見える

### 2. スマホでメニュータップ後、次のページでもタップしたメニュー名（の見た目）が残る
- pathname 変化で閉じる effect は既にある（`Header.tsx:42-45` の `useEffect(() => setMenuOpen(false), [pathname])`）
- 残留の実体は (a) `src/app/components/molecules/HeaderLinkButton.tsx:19` の `hover:opacity-50` がタッチ端末の sticky hover でタップ後も残る、(b) 上記1の group-hover 反転がメニューの閉じアニメーション中に見える
- さらに GitHub リンクは `target="_blank"`（`GithubLinkButton.tsx:18`）で pathname が変わらないため、タップしてもメニューが開いたまま残る

### 3. モバイルメニューの背景をもっと透明に
- `src/app/components/templates/Header.tsx:97-106` — 現在 ライト `bg-white/90`（`supports-[backdrop-filter]:bg-white/70`）＋ `backdrop-blur-md`、ダーク `bg-night-black/90`（supports時 `/70`）

## 変更内容

1. **group スコープ分離**: GithubLinkButton を名前付きグループ化（`group/github` ＋ `group-hover/github:text-main-white` 等）し、nav の無名 `group` と衝突しないようにする。nav 側の `group` は headerMenuItemMotion の `group-data-[open=true]:` 契約で使われているため**削除しない**こと
2. **タッチの sticky hover 解消**: `hover:opacity-50` 等のメニュー項目 hover 演出を hover 対応デバイス限定にする。推奨は `tailwind.config.ts` に `future: { hoverOnlyWhenSupported: true }` を追加（全 hover: が `@media (hover:hover)` 化。副作用が広ければ `[@media(hover:hover)]:hover:opacity-50` の個別指定でも可）
3. **GitHub リンクタップでもメニューを閉じる**: GithubLinkButton に onClick（`setMenuOpen(false)`）を渡して外部リンクタップ時もメニューを閉じる
4. **背景の透明度アップ**: モバイルメニュー背景をライト `bg-white/60` 前後（supports 側は `/50` 前後）へ、ダークも同トーンで下げる。`backdrop-blur-md` は維持し、開いた状態でメニュー文字のコントラスト（可読性）が保たれる範囲で調整

## 完了条件

- `npm run build` 成功、`npm run lint:eslint` パス、既存テスト緑
- 他メニューを hover/タップしても GitHub リンクの色が変わらない
- モバイルビューポートでメニュー項目タップ→遷移後に opacity/反転の残留がない。GitHub リンクタップでもメニューが閉じる
- メニュー背景が現状より明確に透け、かつメニュー文字が読める

---
Workflow `default` completed successfully.

Closes #240

🤖 Generated with takt + Claude Code