### PR TITLE
[#241] UI刷新(11): お問い合わせ送信ボタンのトーンダウン（teal濃色塗りが強すぎる）

### DIFF
--- a/src/app/components/atoms/SubmitButton.style.test.tsx
+++ b/src/app/components/atoms/SubmitButton.style.test.tsx
@@ -90,10 +90,131 @@ test('SubmitButton: 無用化した内側 <p> ラッパを持たない', () => {
   assert.ok(!html.includes('<p'), '<p> を含まない')
 })
 
-test('SubmitButton: 文字色・太字クラスを button に集約する', () => {
+test('SubmitButton: 太字クラスを button に集約する', () => {
   // Given/When: 送信ボタンを描画する
   const html = render()
-  // Then: font-bold と text-main-white が（<p> ではなく）button 上に付与されている
+  // Then: font-bold が（<p> ではなく）button 上に付与されている
   assert.ok(html.includes('font-bold'), 'font-bold を含む')
-  assert.ok(html.includes('text-main-white'), 'text-main-white を含む')
+})
+
+// ── Issue #241 UI刷新(11): 送信ボタンのトーンダウン（TDD 先行） ──
+// 濃色塗り bg-teal(#0F8277)＋白文字を、#233 で確立したチップ体系
+// 「不透明淡色地＋濃色文字」（Tags.tsx: bg-teal-50 text-teal-700）へ揃える。
+// ダーク側の最終トークン（night-teal 系の淡い表現）は draft のコントラスト実測に
+// 委ねられているため、ここでは特定トークンを固定せず「旧強塗りの撤去」と
+// 「ダーク配色の存在」のみを契約化して過剰拘束を避ける。
+// 実装前は bg-teal / text-main-white 等が残るため RED、実装後に GREEN を期待する。
+
+test('SubmitButton: ライト地を不透明淡色 bg-teal-50 で塗る', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: 静かなトーンに揃える #233 チップの淡地トークンを採用している
+  assert.match(html, /\bbg-teal-50\b/, 'bg-teal-50 を含む')
+})
+
+test('SubmitButton: ライト文字を濃色 text-teal-700 にする', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: 淡地に対し AA を満たす濃色文字（#0A5952）を採用している
+  assert.match(html, /\btext-teal-700\b/, 'text-teal-700 を含む')
+})
+
+test('SubmitButton: 濃色 DEFAULT 塗り bg-teal（根本原因）を残さない', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: 主張の強い濃色塗り bg-teal(#0F8277) を撤去する。
+  //       bg-teal-50 / hover:bg-teal-100 等のスケール値には一致させない。
+  assert.ok(!/bg-teal(?![-\w/])/.test(html), '単体の bg-teal を含まない')
+})
+
+test('SubmitButton: 白文字 text-main-white を残さない', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: 濃色塗り前提の白文字は淡色地では成立しないため撤去する
+  assert.ok(!html.includes('text-main-white'), 'text-main-white を含まない')
+})
+
+test('SubmitButton: 旧 hover 濃色化 hover:bg-teal-600 を残さない', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: 濃色塗り時代の hover 深化は淡地トーンに合わないため撤去する
+  assert.ok(!html.includes('hover:bg-teal-600'), 'hover:bg-teal-600 を含まない')
+})
+
+test('SubmitButton: ライトの淡地 hover は同系の淡色（hover:bg-teal-100）', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: 淡地ボタンの hover は同系の一段濃い淡色で軽く反応する
+  assert.match(html, /\bhover:bg-teal-100\b/, 'hover:bg-teal-100 を含む')
+})
+
+test('SubmitButton: 不透明濃塗りシャドウ shadow-card を残さない', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: 浮遊感を強めるカードシャドウは静かなトーンに合わないため撤去する。
+  //       hover:shadow-card-hover も同時に消える。
+  assert.ok(!html.includes('shadow-card'), 'shadow-card を含まない')
+})
+
+test('SubmitButton: ダーク強塗り hover dark:hover:bg-teal-400 を残さない', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: ダークで浮く強い hover 塗りは撤去する（A/B いずれの回避策でも不採用）
+  assert.ok(
+    !html.includes('dark:hover:bg-teal-400'),
+    'dark:hover:bg-teal-400 を含まない',
+  )
+})
+
+test('SubmitButton: ダーク不透明 solid 塗り dark:bg-night-teal を残さない', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: 不透明 solid の dark:bg-night-teal（旧強塗り）を撤去する。
+  //       淡い表現 dark:bg-night-teal/10 等（スラッシュ付き）は許容する。
+  assert.ok(
+    !/dark:bg-night-teal(?![-\w/])/.test(html),
+    '不透明 solid の dark:bg-night-teal を含まない',
+  )
+})
+
+test('SubmitButton: ダークモード配色（night-teal 系の淡い表現）を持つ', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: ライト/ダーク一貫のため dark: 変種のスタイルが付与されている
+  assert.match(html, /\bdark:/, 'dark: バリアントを含む')
+})
+
+// ── #241 リグレッション: ダークモード文字コントラスト AA（family_tag: dark-AA） ──
+// night-gray(#4B4B5A) コンテナ上で dark:text-night-teal を night-teal 低不透明地に
+// 載せると 2.31:1 で AA 未達（supervisor VAL-NEW-SubmitButton-L16-darkAA）。
+// 明るい dark:text-teal-100 へ変更し base 5.74:1 / hover 5.17:1（実測）へ引き上げた。
+// 再発防止のため AA 未達トークンの不在と AA 合格トークンの存在を契約化する。
+
+test('SubmitButton: ダーク文字は AA 未達の text-night-teal を残さない', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: night-teal 低不透明地の上で 2.31:1（AA 未達）になる暗い文字色を撤去する
+  assert.ok(
+    !/dark:text-night-teal\b/.test(html),
+    'dark:text-night-teal を含まない',
+  )
+})
+
+test('SubmitButton: ダーク文字は AA 合格の明色 text-teal-100 にする', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: night-teal 低不透明地に対し 5.74:1（hover 5.17:1）で AA を満たす明色文字を採用する
+  assert.match(html, /\bdark:text-teal-100\b/, 'dark:text-teal-100 を含む')
+})
+
+test('SubmitButton: 送信ボタンと分かるアフォーダンス（境界か淡地）を残す', () => {
+  // Given/When: 送信ボタンを描画する
+  const html = render()
+  // Then: 境界（border）か淡い地色（bg-teal-50）の少なくとも一方でボタンと識別できる
+  const hasBorder = /\bborder\b/.test(html)
+  const hasLightFill = /\bbg-teal-50\b/.test(html)
+  assert.ok(
+    hasBorder || hasLightFill,
+    'border か bg-teal-50 の少なくとも一方を含む',
+  )
 })

--- a/src/app/components/atoms/SubmitButton.tsx
+++ b/src/app/components/atoms/SubmitButton.tsx
@@ -10,10 +10,10 @@ const SubmitButton: React.FC<SubmitButtonProps> = ({ children }) => {
       type="submit"
       className="
         my-10 rounded-full
-        bg-teal px-10 py-4
-        font-bold tracking-wide text-main-white shadow-card transition duration-300
-        hover:-translate-y-0.5 hover:bg-teal-600 hover:shadow-card-hover
-        dark:bg-night-teal dark:hover:bg-teal-400"
+        border border-teal/30 bg-teal-50 px-10 py-4
+        font-bold tracking-wide text-teal-700 transition duration-300
+        hover:-translate-y-0.5 hover:bg-teal-100
+        dark:border-night-teal/40 dark:bg-night-teal/10 dark:text-teal-100 dark:hover:bg-night-teal/20"
     >
       {children}
     </button>


### PR DESCRIPTION
## 概要
GitHub Issue #241「UI刷新(11): お問い合わせ送信ボタンのトーンダウン（teal濃色塗りが強すぎる）」を takt（default workflow: テスト先行）で実装。

## 背景（CEOレビュー 2026-07-02）

お問い合わせページの送信ボタンの色が強くて目立ちすぎている。

- 該当: `src/app/components/atoms/SubmitButton.tsx:11-16`
  ```
  my-10 rounded-full bg-teal px-10 py-4 font-bold tracking-wide text-main-white
  shadow-card transition duration-300 hover:-translate-y-0.5 hover:bg-teal-600
  hover:shadow-card-hover dark:bg-night-teal dark:hover:bg-teal-400
  ```
- `bg-teal`（`#0F8277` の濃色塗り）＋白文字＋シャドウで、静かなトーンのサイトの中で送信ボタンだけ主張が強い
- 使用箇所は `src/app/components/organisms/Form.tsx:48`（/contact）

## 変更内容

送信ボタンを落ち着いたトーンへ。方向性は #233 で確立した「不透明淡色地＋濃色文字」のチップ体系（`bg-teal-50 text-teal-700` 系）と揃える:

- 例: `bg-teal-50 text-teal-700 border border-teal/30 hover:bg-teal-100`（アウトライン/淡色地）
- または濃度を落とした控えめな塗り。いずれもライト/ダーク両方で一貫させること（dark 側は `night-teal` 系の淡い表現に）
- 文字と背景のコントラストは WCAG AA（4.5:1）以上を維持
- 「送信ボタンだと分かる」最低限のアフォーダンス（境界か淡い地色）は残す

## 完了条件

- `npm run build` 成功、`npm run lint:eslint` パス、既存テスト緑
- ライト/ダーク両モードでボタンが浮きすぎず、かつボタンとして識別できる
- コントラスト AA 合格

---
Workflow `default` completed successfully.

Closes #241

🤖 Generated with takt + Claude Code