### PR TITLE
[#242] UI刷新(12): プロフィール各セクションの説明文サイズ統一（passionのul/liにpルールが効いていない）

### DIFF
--- a/src/app/components/molecules/Article.style.test.tsx
+++ b/src/app/components/molecules/Article.style.test.tsx
@@ -1,0 +1,110 @@
+// Article（profile 専用 molecule）の説明文サイズ・行間統一の契約を固定する
+// 単体テスト（Issue #242 UI刷新 12 / TDD 先行）。
+//
+// #242 は profile の4セクション（career/interest/passion/MBTI）の説明文サイズを
+// 揃える。career/interest/MBTI は <p> で globals.css の p ルール
+// （text-sm md:text-base leading-relaxed md:leading-loose）が適用済みだが、
+// passion だけ <ul><li> のため p ルール非適用でブラウザ既定 1rem・レスポンシブなしに
+// なっていた。globals.css へ li/ul の素タグルールを足すと blog 本文・TOC に回帰するため、
+// profile 専用の Article content ラッパ（Article.tsx:23）へ p ルールと同値の
+// text-sm md:text-base leading-relaxed md:leading-loose を付与し、ul/li に継承させる方針。
+// 本テストはその content ラッパのサイズ・行間契約を固定する。
+//
+// 既存の WorkCard.style.test.tsx と同じく node:test と renderToStaticMarkup で構成し、
+// next/image は共有シムへ、.css は空モジュールへ resolve フックで張り替える。
+//
+// 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
+// 実装前は content ラッパにサイズ・行間クラスが無いため RED、実装後に GREEN を期待する。
+
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { before, test } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+const shimUrl = new URL('../__testShims__/nextImage.mjs', import.meta.url).href
+const resolveHook = `
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.endsWith('.css')) {
+    return { url: 'data:text/javascript,export default {}', shortCircuit: true }
+  }
+  if (specifier === 'next/image' && !(context.parentURL || '').includes('__testShims__')) {
+    return { url: ${JSON.stringify(shimUrl)}, shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}
+`
+register(
+  'data:text/javascript,' + encodeURIComponent(resolveHook),
+  import.meta.url,
+)
+;(globalThis as Record<string, unknown>).React = React
+
+type ArticleProps = {
+  title: string
+  content: React.ReactNode
+  imageSrc: string
+  imageAlt: string
+}
+type ArticleComponent = React.FC<ArticleProps>
+
+const baseProps: ArticleProps = {
+  title: '好きなこと',
+  content: (
+    <ul>
+      {['海', '写真'].map((v) => (
+        <li key={v}>{v}</li>
+      ))}
+    </ul>
+  ),
+  imageSrc: '/images/profile/passion.png',
+  imageAlt: 'passion',
+}
+
+let Article: ArticleComponent
+before(async () => {
+  Article = (await import('./Article')).default as unknown as ArticleComponent
+})
+
+// className 属性内で接頭辞なし（素の＝モバイル）ユーティリティとして出現するかを見る。
+// `md:text-base` の中の `text-base` のような接頭辞付き一致を弾き、素の指定だけを検出する。
+const hasBareClass = (html: string, cls: string): boolean =>
+  new RegExp(`[\\s"']${cls.replace(/[-[\]]/g, '\\$&')}[\\s"']`).test(html)
+
+test('Article: content ラッパのモバイル文字サイズを p ルールと同値の text-sm にする', () => {
+  // Given/When: passion の ul/li を content に渡して Article を描画する
+  const html = renderToStaticMarkup(<Article {...baseProps} />)
+  // Then: content ラッパで素の text-sm（モバイル）を継承させる
+  assert.ok(hasBareClass(html, 'text-sm'), '素の text-sm を含む')
+})
+
+test('Article: content ラッパのデスクトップ文字サイズを p ルールと同値の md:text-base にする', () => {
+  // Given/When: Article を描画する
+  const html = renderToStaticMarkup(<Article {...baseProps} />)
+  // Then: md 以上で text-base へ揃える
+  assert.ok(html.includes('md:text-base'), 'md:text-base を含む')
+})
+
+test('Article: content ラッパのモバイル行間を p ルールと同値の leading-relaxed にする', () => {
+  // Given/When: Article を描画する
+  const html = renderToStaticMarkup(<Article {...baseProps} />)
+  // Then: content ラッパで素の leading-relaxed（モバイル）を継承させる
+  assert.ok(
+    hasBareClass(html, 'leading-relaxed'),
+    '素の leading-relaxed を含む',
+  )
+})
+
+test('Article: content ラッパのデスクトップ行間を p ルールと同値の md:leading-loose にする', () => {
+  // Given/When: Article を描画する
+  const html = renderToStaticMarkup(<Article {...baseProps} />)
+  // Then: md 以上で leading-loose へ揃える
+  assert.ok(html.includes('md:leading-loose'), 'md:leading-loose を含む')
+})
+
+test('Article: サイズ指定は arbitrary 値 text-[…] を使わずトークンに揃える', () => {
+  // Given/When: Article を描画する
+  const html = renderToStaticMarkup(<Article {...baseProps} />)
+  // Then: p ルールと同じスケールトークンのみを使い arbitrary 値を残さない
+  assert.ok(!html.includes('text-['), 'text-[ を含まない')
+})

--- a/src/app/components/molecules/Article.tsx
+++ b/src/app/components/molecules/Article.tsx
@@ -20,7 +20,7 @@ const Article: React.FC<ArticleProps> = ({
     <div>
       <h2>{title}</h2>
       <div className="pb-12 pt-4 md:flex">
-        <div className="flex w-full items-center md:w-1/2 md:pr-10">
+        <div className="flex w-full items-center text-sm leading-relaxed md:w-1/2 md:pr-10 md:text-base md:leading-loose">
           {content}
         </div>
         <div className="mt-10 flex w-full justify-center md:mt-0 md:w-1/2">


### PR DESCRIPTION
## 概要
GitHub Issue #242「UI刷新(12): プロフィール各セクションの説明文サイズ統一（passionのul/liにpルールが効いていない）」を takt（default workflow: テスト先行）で実装。

## 背景（CEOレビュー 2026-07-02）

プロフィールページで各セクションの説明文の文字サイズが不揃いでデザインが統一されていない。

監査結果（origin/main）:

- 説明文のサイズは `src/app/globals.css`（section 内）の素タグルールで決まっている: `p { @apply text-sm md:text-base leading-relaxed md:leading-loose noto-sans-jp; }`
- `src/app/(pages)/profile/articles.tsx` の各セクション:
  - 経歴（career）`:33-34` — `<p>` → **text-sm / md:text-base**
  - 興味（interest）`:44` — `<p>` → **text-sm / md:text-base**
  - 好きなこと（passion）`:51-61` — **`<ul><li>`**（`<p>` ではない）→ p ルール非適用＝ブラウザ既定 **1rem**（レスポンシブなし）
  - MBTI `:69-83` — `<p>` → **text-sm / md:text-base**
- つまり「好きなこと」だけ特にモバイルで一回り大きく表示され、不揃いになっている。ラッパ `src/app/components/molecules/Article.tsx:22-25` は content にサイズ指定なし

## 変更内容

- profile の4セクションの説明文を同一の文字サイズ・行間（`text-sm md:text-base leading-relaxed md:leading-loose`）に統一する
- 実装はどちらでも可:
  1. globals.css の section 内ルールに `li`（または `ul`）を追加して p と同格にする — **他ページの li に波及しないかスコープを必ず確認**すること
  2. Article の content ラッパ（`Article.tsx`）にサイズ・行間クラスを持たせ、素タグ依存を減らす
- 見た目の回帰（他ページのリスト表示）が出ない方を選ぶ

## 完了条件

- `npm run build` 成功、`npm run lint:eslint` パス、既存テスト緑
- profile の経歴/興味/好きなこと/MBTI の説明文がモバイル・デスクトップともに同一サイズ・同一行間
- 他ページ（blog 本文等）のリスト表示に回帰がない

---
Workflow `default` completed successfully.

Closes #242

🤖 Generated with takt + Claude Code