### PR TITLE
[#243] UI刷新(13): ブログ説明文の削除＋コピーライトを©2024固定に

### DIFF
--- a/src/app/components/templates/ArticleList.tsx
+++ b/src/app/components/templates/ArticleList.tsx
@@ -87,11 +87,7 @@ const ArticleList: React.FC<ArticleListProps> = ({ initialPosts }) => {
   return (
     <>
       <section>
-        <PageFace
-          title={t.blog.title}
-          subtitle=""
-          mainMessage={<p>{t.blog.lead}</p>}
-        />
+        <PageFace title={t.blog.title} subtitle="" />
       </section>
 
       <AnimatedLine />

--- a/src/app/components/templates/ArticleList.wiring.test.ts
+++ b/src/app/components/templates/ArticleList.wiring.test.ts
@@ -9,9 +9,9 @@
 //   - ChannelLinks を import している
 //   - JSX に <ChannelLinks を配置している
 //   - <ChannelLinks は記事一覧の <Suspense より前（＝上）に置かれている（常設・二重描画回避）
-//   - PageFace に t.blog.lead を配線している（subtitle/mainMessage が空でなくなる）
+//   - PageFace に説明文（t.blog.lead / mainMessage）を配線しない（#243 で削除。空 <p> の余白も残さない）
 //
-// トークン（import 名・<ChannelLinks・<Suspense・t.blog.lead）は Prettier 整形で安定するため、
+// トークン（import 名・<ChannelLinks・<Suspense・t.blog.lead・mainMessage）は Prettier 整形で安定するため、
 // 空白差異に依存しない構造契約として扱う。
 //
 // 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
@@ -53,10 +53,15 @@ test('ArticleList: ChannelLinks を記事一覧（<Suspense）より上に配置
   )
 })
 
-test('ArticleList: PageFace に立ち位置の一文（t.blog.lead）を配線する', () => {
-  // Given/When/Then: 空だった mainMessage/subtitle を lead 文言で埋める
+test('ArticleList: PageFace に説明文（t.blog.lead / mainMessage）を配線しない', () => {
+  // Given/When/Then: 説明文は #243 で削除。lead 参照も mainMessage 配線も残さない
+  // （mainMessage を渡さないことで PageFace の条件付きレンダリングにより要素ごと非表示になり余白が残らない）
   assert.ok(
-    source.includes('t.blog.lead'),
-    't.blog.lead を参照して PageFace に配線する',
+    !source.includes('t.blog.lead'),
+    't.blog.lead を参照しない（#243 で削除）',
+  )
+  assert.ok(
+    !source.includes('mainMessage'),
+    'mainMessage を配線しない（空要素の余白を残さない）',
   )
 })

--- a/src/app/components/templates/Footer.beach.test.tsx
+++ b/src/app/components/templates/Footer.beach.test.tsx
@@ -1,7 +1,7 @@
 // フッター砂浜テーマ刷新（Issue #228 UI刷新 6 / TDD 先行）の契約を固定する単体テスト。
 //
 // #228 は Footer に以下を導入する:
-//   - コピーライトを「© {年} Furugen Island」表示（年は new Date().getFullYear() で動的生成）
+//   - コピーライトを「© 2024 Furugen Island」表示（年は #243 で 2024 固定。旧: 動的生成）
 //   - SNS リンクに Zenn / note を追加（外部リンクは target="_blank" rel="noopener noreferrer"）
 //   - フッター上端に飛び出すビーチ装飾（aria-hidden・クリック不可・ダーク非表示）
 //   - モバイル固定高さ h-32 の解消（h-auto md:h-32 へ）
@@ -85,14 +85,25 @@ test('Footer: コピーライトが Furugen Island 名義で描画される', ()
   assert.ok(html.includes('Furugen Island'), 'Furugen Island を含む')
 })
 
-test('Footer: コピーライトの年が new Date().getFullYear() で動的生成される', () => {
-  // Given: 実行時の現在年
-  const year = String(new Date().getFullYear())
+test('Footer: コピーライトの年が 2024 固定で描画される', () => {
+  // Given/When: フッターを描画する
+  const html = render()
+  // Then: 固定年 2024 が描画される（© 2024 Furugen Island）
+  assert.ok(html.includes('© 2024'), '© 2024 を含む')
+})
+
+test('Footer: コピーライトの年が new Date() の現在年に依存しない', () => {
+  // Given: 実行時の現在年（2024 固定なら本来出力されないはずの値）
+  const currentYear = String(new Date().getFullYear())
   // When: フッターを描画する
   const html = render()
-  // Then: 現在年が描画され、旧固定表記「© 2024 furugen」は残っていない
-  assert.ok(html.includes(year), `現在年 ${year} を含む`)
-  assert.ok(!html.includes('© 2024 furugen'), '旧コピーライト表記を含まない')
+  // Then: 動的年生成へ戻ると現在年が漏れる。現在年が 2024 以外のとき、その年は含まれない
+  if (currentYear !== '2024') {
+    assert.ok(
+      !html.includes(currentYear),
+      `動的な現在年 ${currentYear} を含まない（2024 固定であること）`,
+    )
+  }
 })
 
 test('Footer: Zenn リンクが新規タブ属性付きで描画される', () => {

--- a/src/app/components/templates/Footer.tsx
+++ b/src/app/components/templates/Footer.tsx
@@ -19,7 +19,8 @@ const iconLinks = [
 
 export default function Footer() {
   const { t } = useI18n()
-  const year = new Date().getFullYear()
+  // #243: コピーライト年は 2024 固定（現在年の動的表示を廃止）
+  const year = 2024
 
   return (
     <div className="relative z-20 bg-sand py-10 dark:bg-night-black">

--- a/src/i18n/blog-channels.test.ts
+++ b/src/i18n/blog-channels.test.ts
@@ -1,11 +1,12 @@
-// ブログのハブ化で追加する i18n キー（Issue #229 / TDD 先行）の契約を固定する単体テスト。
+// ブログの i18n キー契約を固定する単体テスト。
 //
-// #229 は次の 2 つを翻訳へ追加する（文言そのものはプロダクト側で自然に調整可）:
-//   - t.blog.lead        : ブログの立ち位置を一言添える文（PageFace に配置）
-//   - t.blog.channels    : { heading, zenn, note } の外部チャンネル導線の文言
-// 型 Translations は ja/en 双方に同一 shape を要求するため片側更新は型エラーになるが、
-// 本テストは「両ロケールでキーが揃い、値が非空文字列である」ことを実行時に明示的に固定する
-// （片側更新・空プレースホルダの防止）。既存 translations.test.ts と同じ流儀で書く。
+// 経緯:
+//   - #229 で t.blog.lead（立ち位置の一文）と t.blog.channels（{ heading, zenn, note }）を追加。
+//   - #243 で t.blog.lead を削除（ブログ説明文の非表示）。channels は維持する。
+// 型 Translations は ja/en 双方に同一 shape を要求するため片側更新は型エラーになる。
+// 本テストは「両ロケールで channels のキーが揃い非空である」ことに加え、
+// 「blog.lead が両ロケールから削除済み（残存しない）」ことを実行時に明示的に固定する
+// （片側取り残し・空プレースホルダ・lead 残存の防止）。既存 translations.test.ts と同じ流儀で書く。
 //
 // 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
 // 実装前は blog.lead / blog.channels 未追加のため RED、実装後に GREEN。
@@ -19,12 +20,11 @@ const LOCALES: Locale[] = ['ja', 'en']
 const CHANNEL_KEYS = ['heading', 'zenn', 'note'] as const
 
 for (const locale of LOCALES) {
-  test(`translations[${locale}]: blog.lead が非空文字列である`, () => {
-    // Given: 当該ロケールの blog ブロック
-    const lead = translations[locale].blog.lead
-    // Then: 立ち位置の一文が非空の文字列で定義されている
-    assert.equal(typeof lead, 'string')
-    assert.ok(lead.length > 0, `blog.lead が空文字（${locale}）`)
+  test(`translations[${locale}]: blog.lead キーを持たない（#243 で削除）`, () => {
+    // Given: 当該ロケールの blog ブロック（型からも lead は除去済みのため cast して残存を検査）
+    const blog = translations[locale].blog as Record<string, unknown>
+    // Then: 説明文（lead）は翻訳キーごと削除され、残存しない
+    assert.equal(blog.lead, undefined, `blog.lead が残存している（${locale}）`)
   })
 
   test(`translations[${locale}]: blog.channels ブロックが存在する`, () => {

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -198,7 +198,6 @@ export const translations: Translations = {
       title: 'ブログ',
       all: 'すべて',
       findOutMore: 'もっと見る',
-      lead: '日々の考えごとや暮らしの記録。技術の話は Zenn、ラフな雑記は note に書いています。',
       channels: {
         heading: '他の場所でも書いています',
         zenn: '技術記事は Zenn へ',
@@ -453,7 +452,6 @@ export const translations: Translations = {
       title: 'Blog',
       all: 'All',
       findOutMore: 'Find Out More',
-      lead: 'Notes on everyday thoughts and daily life. I write about tech on Zenn and casual jottings on note.',
       channels: {
         heading: 'I also write in other places',
         zenn: 'Tech articles on Zenn',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -139,7 +139,6 @@ export type TranslationKeys = {
     title: string
     all: string
     findOutMore: string
-    lead: string
     channels: {
       heading: string
       zenn: string


### PR DESCRIPTION
## 概要
GitHub Issue #243「UI刷新(13): ブログ説明文の削除＋コピーライトを©2024固定に」を takt（default workflow: テスト先行）で実装。

## 背景（CEOレビュー 2026-07-02 / 軽微テキスト2点）

### 1. ブログページの説明文言を削除
「日々の考えごとや暮らしの記録。技術の話は Zenn、ラフな雑記は note に書いています。」を削除したい。

- 日本語: `src/i18n/translations.ts:201` の `lead: '日々の考えごとや暮らしの記録。…'`
- 英語: `src/i18n/translations.ts:456` の `lead: 'Notes on everyday thoughts and daily life. …'`
- 描画経路: `/blog`（`src/app/(pages)/blog/page.tsx`）→ ArticleList → PageFace が `t.blog.lead` を表示

### 2. コピーライトの年を 2024 固定に
フッターが「© 2026」になっている。「© 2024」にしたい。

- `src/app/components/templates/Footer.tsx:22` — `const year = new Date().getFullYear()`（動的に現在年を表示しているため 2026 になる）
- `src/app/components/templates/Footer.tsx:89` — `© {year} {t.footer.copyright}`

## 変更内容

1. blog の `lead` を ja/en とも削除（または空文字）し、PageFace 側で lead が無い場合に**要素ごと非表示**にしてレイアウト（余白）が崩れないようにする。`i18n/blog-channels.test.ts` 等の関連テストが lead を参照していれば合わせて更新
2. Footer の年を `2024` の固定値にする（`new Date()` 依存を排除）。`i18n/footer-copyright.test.ts` が年を検証していれば合わせて更新

## 完了条件

- `npm run build` 成功、`npm run lint:eslint` パス、テスト緑（footer-copyright / blog-channels 含む）
- /blog（ja/en）に説明文が表示されず、見出し周りの余白が不自然でない
- フッターが「© 2024」表示

---
Workflow `default` completed successfully.

Closes #243

🤖 Generated with takt + Claude Code