### PR TITLE
フォントを@fontsource自己ホスト化しGoogle Fontsビルド時フェッチを撤廃

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.107.0",
+        "@fontsource-variable/dm-sans": "^5.2.8",
+        "@fontsource-variable/noto-sans-jp": "^5.2.10",
+        "@fontsource-variable/noto-serif-jp": "^5.2.9",
         "@fortawesome/fontawesome-svg-core": "^6.6.0",
         "@fortawesome/free-brands-svg-icons": "^6.6.0",
         "@fortawesome/free-regular-svg-icons": "^6.7.2",
@@ -712,6 +715,33 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fontsource-variable/dm-sans": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/dm-sans/-/dm-sans-5.2.8.tgz",
+      "integrity": "sha512-AxkvMTvNWgfrmlyjiV05vlHYJa+nRQCf1EfvIrQAPBpFJW0O9VTz7oAFr9S3lvbWdmnFoBk7yFqQL86u64nl2g==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/noto-sans-jp": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/noto-sans-jp/-/noto-sans-jp-5.2.10.tgz",
+      "integrity": "sha512-m0XfZ38rZtCaGAuAQL0cBPQ6fc/RguYEOqw66zvuLOV9vNRUBf9MFqyoazTu2JVCRIcnkrxbwF29UUaHHgTKdg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/noto-serif-jp": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/noto-serif-jp/-/noto-serif-jp-5.2.9.tgz",
+      "integrity": "sha512-FBQiejB8H0Jifs6BzC1yD32MKwdOLk63B/Dwaefauly0b36I6kL1L3a8zre7SWETP3zfe1eP0/H6DUR96jePpg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@fortawesome/fontawesome-common-types": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.107.0",
+    "@fontsource-variable/dm-sans": "^5.2.8",
+    "@fontsource-variable/noto-sans-jp": "^5.2.10",
+    "@fontsource-variable/noto-serif-jp": "^5.2.9",
     "@fortawesome/fontawesome-svg-core": "^6.6.0",
     "@fortawesome/free-brands-svg-icons": "^6.6.0",
     "@fortawesome/free-regular-svg-icons": "^6.7.2",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,7 +22,15 @@
 }
 
 @layer base {
-  /* フォントの設定 */
+  /* フォントの設定
+     ファミリー名は @fontsource-variable/*（layout.tsx で import）の生成名。
+     旧 next/font/google が body className で注入していた変数を :root で定義する */
+  :root {
+    --font-dm-sans: 'DM Sans Variable';
+    --font-noto-sans-jp: 'Noto Sans JP Variable';
+    --font-noto-serif-jp: 'Noto Serif JP Variable';
+  }
+
   .noto-sans-jp {
     font-family: var(--font-noto-sans-jp), sans-serif;
     font-optical-sizing: auto;

--- a/src/app/layout.font.test.ts
+++ b/src/app/layout.font.test.ts
@@ -1,60 +1,74 @@
-// フォント読み込み一本化（Issue #223 UI刷新 1/3 / TDD 先行）の契約を固定する単体テスト。
+// フォント自己ホスト化（Google Fonts 非依存化）の契約を固定する単体テスト。
 //
-// #223 は next/font(Inter) と <link> 直書きの Google Fonts の二重ロードを解消し、
-// next/font/google の DM Sans + Noto Sans JP へ一本化する:
-//   - Inter を削除する
-//   - Google Fonts の <link>（fonts.googleapis.com / fonts.gstatic.com）を全削除する
-//   - next/font/google から DM_Sans / Noto_Sans_JP を読み込む
-// 完了条件「layout.tsx から Google Fonts の <link> タグが消えている」を固定する。
+// 経緯:
+//   - #223 で <link> 直書きを撤去し next/font/google へ一本化した
+//   - その後、next/font/google がビルド/dev 時に Google Fonts へフェッチする性質により
+//     ネットワークが遅い環境で大量の AbortError と起動遅延（コンパイル25秒超）が発生
+//   - @fontsource-variable/* の自己ホストへ移行し、ビルド時のネットワーク依存を撤廃した
+// 契約:
+//   - layout.tsx は Google Fonts のホストにも next/font/google にも依存しない
+//   - DM Sans / Noto Sans JP / Noto Serif JP を @fontsource-variable/* で読み込む
+//   - globals.css が --font-dm-sans / --font-noto-sans-jp / --font-noto-serif-jp を
+//     @fontsource の生成ファミリー名（'... Variable'）へ割り当てる
 //
-// RootLayout を node で描画すると next/font/google の実行に失敗するため、
-// レンダリングではなくソースの静的検査で契約を固定する（plan のテスト観点に従う）。
-//
+// レンダリングではなくソースの静的検査で契約を固定する（従来方針を踏襲）。
 // 実行: プロジェクトルートで `npm test`（node --import tsx --test）。
-// 実装前は Inter / <link> が残っているため RED、実装後に GREEN になることを期待する。
 
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { test } from 'node:test'
 
-const source = readFileSync(new URL('./layout.tsx', import.meta.url), 'utf8')
+const layout = readFileSync(new URL('./layout.tsx', import.meta.url), 'utf8')
+const globals = readFileSync(new URL('./globals.css', import.meta.url), 'utf8')
 
 test('layout: Google Fonts の <link>（fonts.googleapis.com）が消えている', () => {
-  // Given/When: layout.tsx のソース
-  // Then: Google Fonts stylesheet のホストが残っていない
   assert.ok(
-    !source.includes('fonts.googleapis.com'),
+    !layout.includes('fonts.googleapis.com'),
     'fonts.googleapis.com を含まない',
   )
 })
 
 test('layout: preconnect 先（fonts.gstatic.com）も消えている', () => {
-  // Given/When: layout.tsx のソース
-  // Then: Google Fonts の preconnect も残っていない
   assert.ok(
-    !source.includes('fonts.gstatic.com'),
+    !layout.includes('fonts.gstatic.com'),
     'fonts.gstatic.com を含まない',
   )
 })
 
-test('layout: Inter を読み込まない（next/font から削除されている）', () => {
-  // Given/When: layout.tsx のソース
-  // Then: Inter への参照が残っていない
-  assert.ok(!source.includes('Inter'), 'Inter を含まない')
+test('layout: Inter を読み込まない', () => {
+  assert.ok(!layout.includes('Inter'), 'Inter を含まない')
 })
 
-test('layout: next/font/google に一本化されている', () => {
-  // Given/When: layout.tsx のソース
-  // Then: next/font/google を利用している
+test('layout: next/font/google に依存しない（ビルド時フェッチの再混入防止）', () => {
+  assert.ok(!layout.includes('next/font/google'), 'next/font/google を含まない')
+})
+
+test('layout: 3ファミリーを @fontsource-variable で自己ホストする', () => {
   assert.ok(
-    source.includes('next/font/google'),
-    'next/font/google を利用している',
+    layout.includes('@fontsource-variable/dm-sans'),
+    'DM Sans を @fontsource で読み込む',
+  )
+  assert.ok(
+    layout.includes('@fontsource-variable/noto-sans-jp'),
+    'Noto Sans JP を @fontsource で読み込む',
+  )
+  assert.ok(
+    layout.includes('@fontsource-variable/noto-serif-jp'),
+    'Noto Serif JP を @fontsource で読み込む',
   )
 })
 
-test('layout: DM Sans と Noto Sans JP を next/font で読み込む', () => {
-  // Given/When: layout.tsx のソース
-  // Then: DM_Sans / Noto_Sans_JP を import している
-  assert.ok(source.includes('DM_Sans'), 'DM_Sans を読み込む')
-  assert.ok(source.includes('Noto_Sans_JP'), 'Noto_Sans_JP を読み込む')
+test('globals.css: --font-* 変数を @fontsource の生成ファミリー名へ割り当てる', () => {
+  assert.ok(
+    globals.includes("--font-dm-sans: 'DM Sans Variable'"),
+    '--font-dm-sans を定義する',
+  )
+  assert.ok(
+    globals.includes("--font-noto-sans-jp: 'Noto Sans JP Variable'"),
+    '--font-noto-sans-jp を定義する',
+  )
+  assert.ok(
+    globals.includes("--font-noto-serif-jp: 'Noto Serif JP Variable'"),
+    '--font-noto-serif-jp を定義する',
+  )
 })

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,30 +3,16 @@ import '@fortawesome/fontawesome-svg-core/styles.css'
 import { GoogleAnalytics, GoogleTagManager } from '@next/third-parties/google'
 import type { Metadata } from 'next'
 import { ThemeProvider } from 'next-themes'
-import { DM_Sans, Noto_Sans_JP, Noto_Serif_JP } from 'next/font/google'
+// フォントは Google Fonts へのビルド時フェッチをやめ @fontsource で自己ホストする
+// （旧方式はネットワークが遅い環境で大量タイムアウトし dev/build を止めていた）。
+// unicode-range 分割された CSS + woff2 が _next/static に同梱される。
+// 各ファミリーと --font-* CSS 変数の対応は globals.css で定義する。
+import '@fontsource-variable/dm-sans'
+import '@fontsource-variable/noto-sans-jp'
+// book / tanka の縦書き明朝スタック（weight 300/400/500）が可変フォント1面でまかなえる
+import '@fontsource-variable/noto-serif-jp'
 import 'tailwindcss/tailwind.css'
 import './globals.css'
-
-const dmSans = DM_Sans({
-  subsets: ['latin'],
-  display: 'swap',
-  variable: '--font-dm-sans',
-})
-
-const notoSansJP = Noto_Sans_JP({
-  subsets: ['latin'],
-  display: 'swap',
-  variable: '--font-noto-sans-jp',
-})
-
-// book / tanka の縦書き明朝スタックが名指し参照するため next/font で読み込む。
-// 非可変フォントのため実際に使う weight（book:300/400, TankaCard:500）を明示する
-const notoSerifJP = Noto_Serif_JP({
-  weight: ['300', '400', '500'],
-  subsets: ['latin'],
-  display: 'swap',
-  variable: '--font-noto-serif-jp',
-})
 
 export const metadata: Metadata = {
   title:
@@ -68,9 +54,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja" suppressHydrationWarning={true}>
-      <body
-        className={`${dmSans.variable} ${notoSansJP.variable} ${notoSerifJP.variable}`}
-      >
+      <body>
         <ThemeProvider attribute="class">
           <ClientWrapper>{children}</ClientWrapper>
         </ThemeProvider>


### PR DESCRIPTION
## 背景
`next/font/google` は dev/build 時に Google Fonts へフォントファイルを取りに行く。ネットワークが遅い環境（自宅サーバー）で3秒タイムアウトが大量発生し（AbortError の嵐）、dev 起動が25秒超になっていた。

## 変更
- DM Sans / Noto Sans JP / Noto Serif JP を `@fontsource-variable/*` の自己ホストへ移行（npm依存としてフォント同梱・ビルド時ネットワーク非依存）
- unicode-range 分割（Noto Sans JP 124分割等）は @fontsource の CSS がそのまま持つため、**ブラウザへの配信サイズは従来同等**
- `--font-dm-sans` / `--font-noto-sans-jp` / `--font-noto-serif-jp` は `globals.css` の `:root` で定義（body className 注入を廃止）。参照側は全て `var(--font-*)` 経由のため変更不要
- `layout.font.test.ts` を新契約（自己ホスト・`next/font/google` 再混入防止）へ更新

## 検証
- `npm test`: 432/432 pass
- `npm run build`: 成功（フォント250 woff2 が `_next/static/media` に同梱）
- dev 起動: Ready 1.5s / AbortError 0件 / `GET /my_site` 200（従来は初回26秒）

## 留意点（軽微なトレードオフ）
- next/font が自動生成していたフォールバックフォントのメトリクス調整（CLS対策）と latin サブセットの preload はなくなる。`font-display: swap` は維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)